### PR TITLE
Fix forgot password endpoint

### DIFF
--- a/api/src/routes/auth/SiteAuth.ts
+++ b/api/src/routes/auth/SiteAuth.ts
@@ -59,7 +59,7 @@ siteAuth.post('/login', async (req, res, next) => {
 siteAuth.post('/forgotPassword', async (req, res) => {
     const { email, username } = req.body;
     if (!email || !username) {
-        res.status(400);
+        res.sendStatus(400);
         return;
     }
     const user = await getUserByEmail(email);

--- a/web/src/app/(main)/forgotpass/page.tsx
+++ b/web/src/app/(main)/forgotpass/page.tsx
@@ -36,6 +36,9 @@ export default function ForgotPassword() {
                     onSubmit={async ({ email, username }) => {
                         const res = await fetch('/api/auth/forgotPassword', {
                             method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
                             body: JSON.stringify({ email, username }),
                         });
                         if (!res.ok) {


### PR DESCRIPTION
Ensure that the forgot password endpoint sends the response in all error cases, and that the client json encodes the request