### PR TITLE
Rework room layout

### DIFF
--- a/web/src/app/(main)/rooms/[slug]/page.tsx
+++ b/web/src/app/(main)/rooms/[slug]/page.tsx
@@ -115,7 +115,7 @@ function RoomXs() {
             <Box>
                 <PlayerList />
             </Box>
-            <Box maxHeight="100%">
+            <Box maxHeight="90%">
                 <RoomChat />
             </Box>
         </>
@@ -140,7 +140,7 @@ function RoomSm() {
             <Box>
                 <PlayerList />
             </Box>
-            <Box maxHeight="100%">
+            <Box maxHeight="90%">
                 <RoomChat />
             </Box>
         </>
@@ -176,7 +176,7 @@ function RoomMd() {
                     <PlayerList />
                 </Box>
             </Box>
-            <Box px={4} maxHeight="100%">
+            <Box px={4} maxHeight="90%">
                 <RoomChat />
             </Box>
         </>
@@ -201,6 +201,7 @@ function RoomLg() {
                 flexDirection="column"
                 rowGap={1}
                 maxHeight="100%"
+                sx={{ overflowY: 'auto' }}
             >
                 <Box>
                     <RoomInfo />
@@ -214,7 +215,7 @@ function RoomLg() {
                 <Box>
                     <PlayerList />
                 </Box>
-                <Box maxHeight="100%">
+                <Box maxHeight="85%">
                     <RoomChat />
                 </Box>
             </Box>
@@ -225,16 +226,31 @@ function RoomLg() {
 function RoomXl() {
     return (
         <>
-            <Box flexGrow={1} maxWidth="50%" maxHeight="100%">
+            <Box
+                flexGrow={1}
+                maxWidth="50%"
+                maxHeight="100%"
+                display="flex"
+                alignContent="center"
+                justifyContent="center"
+            >
                 <Board />
             </Box>
-            <Box display="flex" columnGap={1}>
-                <Box display="flex" flexDirection="column" rowGap={1}>
-                    <Box>
-                        <RoomInfo />
-                    </Box>
-                    <Box>
-                        <RacetimeCard />
+            <Box display="flex" columnGap={1} maxWidth="50%" maxHeight="100%">
+                <Box
+                    display="flex"
+                    flexDirection="column"
+                    rowGap={1}
+                    maxHeight="100%"
+                    sx={{ overflowY: 'auto' }}
+                >
+                    <Box display="flex" columnGap={1}>
+                        <Box>
+                            <RoomInfo />
+                        </Box>
+                        <Box>
+                            <RacetimeCard />
+                        </Box>
                     </Box>
                     <Box>
                         <PlayerInfo />
@@ -243,7 +259,7 @@ function RoomXl() {
                         <PlayerList />
                     </Box>
                 </Box>
-                <Box>
+                <Box flexGrow={1} maxWidth="40%">
                     <RoomChat />
                 </Box>
             </Box>

--- a/web/src/app/(main)/rooms/[slug]/page.tsx
+++ b/web/src/app/(main)/rooms/[slug]/page.tsx
@@ -1,36 +1,17 @@
 'use client';
 import Board from '@/components/board/Board';
-import ColorSelect from '@/components/room/ColorSelect';
 import RoomChat from '@/components/room/RoomChat';
 import RoomInfo from '@/components/room/RoomInfo';
 import RoomLogin from '@/components/room/RoomLogin';
-import { ConnectionStatus, RoomContext } from '@/context/RoomContext';
-import Refresh from '@mui/icons-material/Refresh';
-import {
-    Box,
-    Button,
-    Card,
-    CardContent,
-    IconButton,
-    Link,
-    Typography,
-} from '@mui/material';
-import NextLink from 'next/link';
-import { useContext } from 'react';
+import { ConnectionStatus, useRoomContext } from '@/context/RoomContext';
+import { Box, Container } from '@mui/material';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import PlayerList from '../../../../components/room/PlayerList';
-import Timer from '../../../../components/room/racetime/Timer';
 import RacetimeCard from '../../../../components/room/racetime/RacetimeCard';
+import PlayerInfo from '../../../../components/room/PlayerInfo';
 
 export default function Room() {
-    const {
-        connectionStatus,
-        roomData,
-        nickname,
-        disconnect,
-        createRacetimeRoom,
-        updateRacetimeRoom,
-    } = useContext(RoomContext);
+    const { connectionStatus, roomData } = useRoomContext();
 
     if (connectionStatus === ConnectionStatus.UNINITIALIZED) {
         return <RoomLogin />;
@@ -44,72 +25,225 @@ export default function Room() {
     }
 
     return (
-        <Box flex="column" flexGrow={1} p={2}>
-            <AutoSizer>
-                {({ width, height }) => (
+        <AutoSizer>
+            {({ width, height }) => (
+                <>
                     <Box
-                        width={width}
-                        height={height}
-                        display="flex"
-                        flexDirection="column"
+                        sx={{
+                            display: { xs: 'flex', sm: 'none' },
+                            width: width,
+                            height: height,
+                            overflowY: 'auto',
+                            flexDirection: 'column',
+                            rowGap: 1.5,
+                            p: 1,
+                        }}
                     >
-                        <Box
-                            display="flex"
-                            columnGap={2}
-                            maxHeight="30%"
-                            pb={2}
-                        >
-                            <Box>
-                                <RoomInfo />
-                            </Box>
-                            <Box>
-                                <Card>
-                                    <CardContent>
-                                        <Box
-                                            display="flex"
-                                            alignItems="center"
-                                            flexGrow={1}
-                                        >
-                                            <Typography
-                                                variant="h6"
-                                                flexGrow={1}
-                                            >
-                                                Playing as {nickname}
-                                            </Typography>
-                                            {connectionStatus !==
-                                                ConnectionStatus.CLOSED && (
-                                                <Button onClick={disconnect}>
-                                                    Disconnect
-                                                </Button>
-                                            )}
-                                        </Box>
-                                        <Box>
-                                            <Typography>
-                                                Choose your color
-                                            </Typography>
-                                            <ColorSelect />
-                                        </Box>
-                                    </CardContent>
-                                </Card>
-                            </Box>
-                            <Box>
-                                <RacetimeCard />
-                            </Box>
-                        </Box>
-                        <Box display="flex" maxHeight="70%" columnGap={8}>
-                            <Box flexGrow={1} maxWidth="50%">
-                                <Board />
-                            </Box>
-                            <Box>
-                                <RoomChat />
-                            </Box>
-                            <Box>
-                                <PlayerList />
-                            </Box>
-                        </Box>
+                        <RoomXs />
                     </Box>
-                )}
-            </AutoSizer>
-        </Box>
+                    <Box
+                        sx={{
+                            display: { xs: 'none', sm: 'flex', md: 'none' },
+                            width: width,
+                            height: height,
+                            overflowY: 'auto',
+                            flexDirection: 'column',
+                            rowGap: 1.5,
+                            p: 1,
+                        }}
+                    >
+                        <RoomSm />
+                    </Box>
+                    <Box
+                        sx={{
+                            display: { xs: 'none', md: 'flex', lg: 'none' },
+                            width: width,
+                            height: height,
+                            overflowY: 'auto',
+                            flexDirection: 'column',
+                            rowGap: 1.5,
+                            p: 1,
+                        }}
+                    >
+                        <RoomMd />
+                    </Box>
+                    <Box
+                        sx={{
+                            display: { xs: 'none', lg: 'flex', xl: 'none' },
+                            width: width,
+                            height: height,
+                            overflowY: 'auto',
+                            p: 1,
+                        }}
+                    >
+                        <RoomLg />
+                    </Box>
+                    <Box
+                        sx={{
+                            display: { xs: 'none', xl: 'flex' },
+                            width: width,
+                            height: height,
+                            overflowY: 'auto',
+                            p: 1,
+                        }}
+                    >
+                        <RoomXl />
+                    </Box>
+                </>
+            )}
+        </AutoSizer>
+    );
+}
+
+function RoomXs() {
+    return (
+        <>
+            xs
+            <Box>
+                <RoomInfo />
+            </Box>
+            <Box>
+                <RacetimeCard />
+            </Box>
+            <Box>
+                <PlayerInfo />
+            </Box>
+            <Box maxWidth="100%" maxHeight="100%">
+                <Board />
+            </Box>
+            <Box>
+                <PlayerList />
+            </Box>
+            <Box>
+                <RoomChat />
+            </Box>
+        </>
+    );
+}
+
+function RoomSm() {
+    return (
+        <>
+            small
+            <Box display="flex" columnGap={2}>
+                <Box flexGrow={1}>
+                    <RoomInfo />
+                </Box>
+                <Box>
+                    <RacetimeCard />
+                </Box>
+            </Box>
+            <Box>
+                <PlayerInfo />
+            </Box>
+            <Box maxWidth="80%" maxHeight="100">
+                <Board />
+            </Box>
+            <Box>
+                <PlayerList />
+            </Box>
+            <Box>
+                <RoomChat />
+            </Box>
+        </>
+    );
+}
+
+function RoomMd() {
+    return (
+        <>
+            <Box display="flex" columnGap={2}>
+                <Box flexGrow={1}>
+                    <RoomInfo />
+                </Box>
+                <Box>
+                    <PlayerInfo />
+                </Box>
+            </Box>
+            <Box>
+                <RacetimeCard />
+            </Box>
+            <Box
+                maxWidth="100%"
+                maxHeight="100%"
+                display="flex"
+                columnGap={1}
+                alignContent="center"
+                justifyContent="center"
+            >
+                <Box width="75%" maxHeight="100%">
+                    <Board />
+                </Box>
+                <Box>
+                    <PlayerList />
+                </Box>
+            </Box>
+            <Box px={4}>
+                <RoomChat />
+            </Box>
+        </>
+    );
+}
+
+function RoomLg() {
+    return (
+        <>
+            <Box
+                flexGrow={1}
+                maxWidth="75%"
+                maxHeight="100%"
+                display="flex"
+                alignContent="center"
+                justifyContent="center"
+            >
+                <Board />
+            </Box>
+            <Box display="flex" flexDirection="column" rowGap={1}>
+                <Box>
+                    <RoomInfo />
+                </Box>
+                <Box>
+                    <PlayerInfo />
+                </Box>
+                <Box>
+                    <RacetimeCard />
+                </Box>
+                <Box>
+                    <PlayerList />
+                </Box>
+                <Box>
+                    <RoomChat />
+                </Box>
+            </Box>
+        </>
+    );
+}
+
+function RoomXl() {
+    return (
+        <>
+            <Box flexGrow={1} maxWidth="50%" maxHeight="100%">
+                <Board />
+            </Box>
+            <Box display="flex" flexDirection="column" rowGap={1}>
+                <Box display="flex" columnGap={1}>
+                    <Box flexGrow={1}>
+                        <RoomInfo />
+                    </Box>
+                    <RacetimeCard />
+                </Box>
+                <Box>
+                    <PlayerInfo />
+                </Box>
+                <Box display="flex" columnGap={1}>
+                    <Box>
+                        <RoomChat />
+                    </Box>
+                    <Box>
+                        <PlayerList />
+                    </Box>
+                </Box>
+            </Box>
+        </>
     );
 }

--- a/web/src/app/(main)/rooms/[slug]/page.tsx
+++ b/web/src/app/(main)/rooms/[slug]/page.tsx
@@ -73,6 +73,7 @@ export default function Room() {
                             width: width,
                             height: height,
                             overflowY: 'auto',
+                            columnGap: 1,
                             p: 1,
                         }}
                     >
@@ -84,6 +85,7 @@ export default function Room() {
                             width: width,
                             height: height,
                             overflowY: 'auto',
+                            columnGap: 1,
                             p: 1,
                         }}
                     >
@@ -98,7 +100,6 @@ export default function Room() {
 function RoomXs() {
     return (
         <>
-            xs
             <Box>
                 <RoomInfo />
             </Box>
@@ -114,7 +115,7 @@ function RoomXs() {
             <Box>
                 <PlayerList />
             </Box>
-            <Box>
+            <Box maxHeight="100%">
                 <RoomChat />
             </Box>
         </>
@@ -124,25 +125,22 @@ function RoomXs() {
 function RoomSm() {
     return (
         <>
-            small
-            <Box display="flex" columnGap={2}>
-                <Box flexGrow={1}>
-                    <RoomInfo />
-                </Box>
-                <Box>
-                    <RacetimeCard />
-                </Box>
+            <Box flexGrow={1}>
+                <RoomInfo />
+            </Box>
+            <Box>
+                <RacetimeCard />
             </Box>
             <Box>
                 <PlayerInfo />
             </Box>
-            <Box maxWidth="80%" maxHeight="100">
+            <Box maxWidth="100%" maxHeight="100%">
                 <Board />
             </Box>
             <Box>
                 <PlayerList />
             </Box>
-            <Box>
+            <Box maxHeight="100%">
                 <RoomChat />
             </Box>
         </>
@@ -157,11 +155,11 @@ function RoomMd() {
                     <RoomInfo />
                 </Box>
                 <Box>
-                    <PlayerInfo />
+                    <RacetimeCard />
                 </Box>
             </Box>
             <Box>
-                <RacetimeCard />
+                <PlayerInfo />
             </Box>
             <Box
                 maxWidth="100%"
@@ -178,7 +176,7 @@ function RoomMd() {
                     <PlayerList />
                 </Box>
             </Box>
-            <Box px={4}>
+            <Box px={4} maxHeight="100%">
                 <RoomChat />
             </Box>
         </>
@@ -198,7 +196,12 @@ function RoomLg() {
             >
                 <Board />
             </Box>
-            <Box display="flex" flexDirection="column" rowGap={1}>
+            <Box
+                display="flex"
+                flexDirection="column"
+                rowGap={1}
+                maxHeight="100%"
+            >
                 <Box>
                     <RoomInfo />
                 </Box>
@@ -211,7 +214,7 @@ function RoomLg() {
                 <Box>
                     <PlayerList />
                 </Box>
-                <Box>
+                <Box maxHeight="100%">
                     <RoomChat />
                 </Box>
             </Box>
@@ -225,23 +228,23 @@ function RoomXl() {
             <Box flexGrow={1} maxWidth="50%" maxHeight="100%">
                 <Board />
             </Box>
-            <Box display="flex" flexDirection="column" rowGap={1}>
-                <Box display="flex" columnGap={1}>
-                    <Box flexGrow={1}>
+            <Box display="flex" columnGap={1}>
+                <Box display="flex" flexDirection="column" rowGap={1}>
+                    <Box>
                         <RoomInfo />
                     </Box>
-                    <RacetimeCard />
-                </Box>
-                <Box>
-                    <PlayerInfo />
-                </Box>
-                <Box display="flex" columnGap={1}>
                     <Box>
-                        <RoomChat />
+                        <RacetimeCard />
+                    </Box>
+                    <Box>
+                        <PlayerInfo />
                     </Box>
                     <Box>
                         <PlayerList />
                     </Box>
+                </Box>
+                <Box>
+                    <RoomChat />
                 </Box>
             </Box>
         </>

--- a/web/src/components/room/PlayerInfo.tsx
+++ b/web/src/components/room/PlayerInfo.tsx
@@ -1,0 +1,25 @@
+import { Card, CardContent, Box, Typography, Button } from '@mui/material';
+import { ConnectionStatus, useRoomContext } from '../../context/RoomContext';
+import ColorSelect from './ColorSelect';
+
+export default function PlayerInfo() {
+    const { connectionStatus, nickname, disconnect } = useRoomContext();
+    return (
+        <Card>
+            <CardContent>
+                <Box display="flex" alignItems="center" flexGrow={1}>
+                    <Typography variant="h6" flexGrow={1}>
+                        Playing as {nickname}
+                    </Typography>
+                    {connectionStatus !== ConnectionStatus.CLOSED && (
+                        <Button onClick={disconnect}>Disconnect</Button>
+                    )}
+                </Box>
+                <Box>
+                    <Typography>Choose your color</Typography>
+                    <ColorSelect />
+                </Box>
+            </CardContent>
+        </Card>
+    );
+}

--- a/web/src/components/room/PlayerList.tsx
+++ b/web/src/components/room/PlayerList.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { RoomContext } from '../../context/RoomContext';
-import { Box, Paper, Typography } from '@mui/material';
+import { Box, Card, CardContent, CardHeader, Typography } from '@mui/material';
 import { Duration } from 'luxon';
 
 export default function PlayerList() {
@@ -8,50 +8,60 @@ export default function PlayerList() {
     const racetimeConnected = !!roomData?.racetimeConnection?.url;
 
     return (
-        <Paper
+        <Card
             sx={{
                 maxHeight: '100%',
-                overflowY: 'auto',
-                px: 1.5,
-                pt: 1,
-                pb: 1.5,
+                // overflowY: 'auto',
+                py: 1,
             }}
         >
-            <Typography variant="h6" pb={1}>
-                Connected Players
-            </Typography>
-            <Box display="flex" flexDirection="column" rowGap={3}>
-                {players.map((player) => (
-                    <Box key={player.nickname}>
-                        <Box display="flex" columnGap={2}>
-                            <Box
-                                px={0.5}
-                                style={{ background: player.color }}
-                                border={1}
-                                borderColor="divider"
-                            >
-                                <Typography>{player.goalCount}</Typography>
+            <CardHeader
+                title={`Connected Players (${players.length})`}
+                titleTypographyProps={{ variant: 'h6' }}
+                sx={{ py: 0 }}
+            />
+            <CardContent sx={{ maxHeight: '80%', overflowY: 'auto' }}>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        rowGap: 1,
+                        overflowY: 'auto',
+                        maxHeight: '100%',
+                    }}
+                >
+                    {players.map((player) => (
+                        <Box key={player.nickname}>
+                            <Box display="flex" columnGap={2}>
+                                <Box
+                                    px={0.5}
+                                    style={{ background: player.color }}
+                                    border={1}
+                                    borderColor="divider"
+                                >
+                                    <Typography>{player.goalCount}</Typography>
+                                </Box>
+                                <Typography>{player.nickname}</Typography>
                             </Box>
-                            <Typography>{player.nickname}</Typography>
+                            {racetimeConnected && (
+                                <>
+                                    {!player.racetimeStatus.connected && (
+                                        <Typography>Not connected</Typography>
+                                    )}
+                                    {player.racetimeStatus.connected && (
+                                        <Typography>
+                                            {player.racetimeStatus.username} -{' '}
+                                            {player.racetimeStatus.status}
+                                            {player.racetimeStatus.finishTime &&
+                                                ` - ${Duration.fromISO(player.racetimeStatus.finishTime).toFormat('h:mm:ss')}`}
+                                        </Typography>
+                                    )}
+                                </>
+                            )}
                         </Box>
-                        {racetimeConnected && (
-                            <>
-                                {!player.racetimeStatus.connected && (
-                                    <Typography>Not connected</Typography>
-                                )}
-                                {player.racetimeStatus.connected && (
-                                    <Typography>
-                                        {player.racetimeStatus.username} -{' '}
-                                        {player.racetimeStatus.status}
-                                        {player.racetimeStatus.finishTime &&
-                                            ` - ${Duration.fromISO(player.racetimeStatus.finishTime).toFormat('h:mm:ss')}`}
-                                    </Typography>
-                                )}
-                            </>
-                        )}
-                    </Box>
-                ))}
-            </Box>
-        </Paper>
+                    ))}
+                </Box>
+            </CardContent>
+        </Card>
     );
 }

--- a/web/src/components/room/RoomChat.tsx
+++ b/web/src/components/room/RoomChat.tsx
@@ -12,7 +12,7 @@ export default function RoomChat() {
     const chatDivRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        chatDivRef.current?.scrollIntoView(false);
+        chatDivRef.current?.scrollTo(0, chatDivRef.current.scrollHeight);
     }, [messages]);
 
     return (
@@ -32,6 +32,7 @@ export default function RoomChat() {
                     overflowY: 'auto',
                     px: 1,
                 }}
+                ref={chatDivRef}
             >
                 {messages.map((message, index) => (
                     <div key={index}>
@@ -56,7 +57,6 @@ export default function RoomChat() {
                         })}
                     </div>
                 ))}
-                <div ref={chatDivRef} />
             </Box>
             <Box display="flex" columnGap={1}>
                 <TextField


### PR DESCRIPTION
Reworks the room layout to further emphasize the board, so long as the screen is wide enough. Introduces dedicated layouts for the standard material screen width breakpoints to allow each screen size to be customized as necessary. Small screens utilize vertical scrolling, while larger screens utilize their width and have multiple columns (which can scroll independently). Content is designed to fit in or be constrained to a single screen height for each layout


Note that this does not do anything to help when the window is too short, PlayBingo currently does not support narrow resolutions and likely will not ever.