### PR TITLE
Difficulty Variants

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,7 @@
         "seed": "ts-node prisma/seed.ts"
     },
     "scripts": {
-        "dev": "tsc-watch --noClear --onSuccess \"node build/main.js\"",
+        "dev": "tsc-watch --noClear --onSuccess \"node build/src/main.js\"",
         "db:reset": "prisma migrate reset",
         "db:migrate": "prisma migrate dev",
         "db:seed": "prisma db seed",

--- a/api/prisma/migrations/20241111231144_add_difficulty_variants/migration.sql
+++ b/api/prisma/migrations/20241111231144_add_difficulty_variants/migration.sql
@@ -1,0 +1,19 @@
+-- AlterTable
+ALTER TABLE "Game" ADD COLUMN     "difficultyGroups" INTEGER,
+ADD COLUMN     "difficultyVariantsEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "DifficultyVariant" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "goalAmounts" INTEGER[],
+    "gameId" TEXT,
+
+    CONSTRAINT "DifficultyVariant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DifficultyVariant_id_key" ON "DifficultyVariant"("id");
+
+-- AddForeignKey
+ALTER TABLE "DifficultyVariant" ADD CONSTRAINT "DifficultyVariant_gameId_fkey" FOREIGN KEY ("gameId") REFERENCES "Game"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -45,22 +45,33 @@ model Variant {
 }
 
 model Game {
-  id               String    @id @unique @default(cuid())
-  name             String
-  slug             String    @unique
-  coverImage       String?
-  variants         Variant[]
-  goals            Goal[]
-  owners           User[]    @relation("GameOwners")
-  moderators       User[]    @relation("GameModerators")
-  createdAt        DateTime  @default(now())
-  updatedAt        DateTime  @updatedAt
-  enableSRLv5      Boolean   @default(false)
-  rooms            Room[]
-  racetimeCategory String?
-  racetimeGoal     String?
-  racetimeBeta     Boolean   @default(false)
-  usersFavorited   User[]    @relation("GameFavorites")
+  id                        String              @id @unique @default(cuid())
+  name                      String
+  slug                      String              @unique
+  coverImage                String?
+  variants                  Variant[]
+  goals                     Goal[]
+  owners                    User[]              @relation("GameOwners")
+  moderators                User[]              @relation("GameModerators")
+  createdAt                 DateTime            @default(now())
+  updatedAt                 DateTime            @updatedAt
+  enableSRLv5               Boolean             @default(false)
+  rooms                     Room[]
+  racetimeCategory          String?
+  racetimeGoal              String?
+  racetimeBeta              Boolean             @default(false)
+  usersFavorited            User[]              @relation("GameFavorites")
+  difficultyVariantsEnabled Boolean             @default(false)
+  difficultyVariants        DifficultyVariant[]
+  difficultyGroups          Int?
+}
+
+model DifficultyVariant {
+  id          String  @id @unique @default(cuid())
+  name        String
+  goalAmounts Int[]
+  Game        Game?   @relation(fields: [gameId], references: [id])
+  gameId      String?
 }
 
 model User {

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -40,7 +40,7 @@ model Variant {
   name        String
   description String
   goals       GoalVariant[]
-  Game        Game?         @relation(fields: [gameId], references: [id])
+  game        Game?         @relation(fields: [gameId], references: [id])
   gameId      String?
 }
 
@@ -70,7 +70,7 @@ model DifficultyVariant {
   id          String  @id @unique @default(cuid())
   name        String
   goalAmounts Int[]
-  Game        Game?   @relation(fields: [gameId], references: [id])
+  game        Game?   @relation(fields: [gameId], references: [id])
   gameId      String?
 }
 

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -159,11 +159,15 @@ export default class Room {
                         return max;
                     }, 0);
                     const groupSize = maxDifficulty / numGroups;
+                    const emptyGroupedGoals = [];
+                    for (let i = 0; i < numGroups; i++) {
+                        emptyGroupedGoals.push([]);
+                    }
                     const groupedGoals = goals.reduce<Goal[][]>(
                         (curr, goal) => {
                             if (goal.difficulty && goal.difficulty > 0) {
                                 const grpIdx = Math.floor(
-                                    goal.difficulty / groupSize,
+                                    (goal.difficulty - 1) / groupSize,
                                 );
 
                                 goal.goal = `${goal.goal} (${goal.difficulty} => ${grpIdx})`;
@@ -173,12 +177,12 @@ export default class Room {
                             }
                             return curr;
                         },
-                        Array(numGroups).fill([]),
+                        emptyGroupedGoals,
                     );
                     goalList = [];
                     groupedGoals.forEach((group, index) => {
                         shuffle(group);
-                        const toAdd = goals.splice(
+                        const toAdd = group.splice(
                             0,
                             variant.goalAmounts[index],
                         );

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -169,8 +169,6 @@ export default class Room {
                                 const grpIdx = Math.floor(
                                     (goal.difficulty - 1) / groupSize,
                                 );
-
-                                goal.goal = `${goal.goal} (${goal.difficulty} => ${grpIdx})`;
                                 if (grpIdx < numGroups) {
                                     curr[grpIdx].push(goal);
                                 }

--- a/api/src/database/games/Games.ts
+++ b/api/src/database/games/Games.ts
@@ -7,6 +7,7 @@ export const allGames = async (user?: string) => {
         include: {
             owners: { select: { id: true } },
             moderators: { select: { id: true } },
+            difficultyVariants: { select: { name: true, goalAmounts: true } },
         },
     });
     if (user) {
@@ -35,6 +36,7 @@ export const gameForSlug = (slug: string) => {
             moderators: {
                 select: { id: true, username: true },
             },
+            difficultyVariants: { select: { name: true, goalAmounts: true } },
         },
     });
 };
@@ -99,6 +101,18 @@ export const updateGameCover = (slug: string, coverImage: string) => {
 
 export const updateSRLv5Enabled = (slug: string, enableSRLv5: boolean) => {
     return prisma.game.update({ where: { slug }, data: { enableSRLv5 } });
+};
+
+export const updateDifficultyVariantsEnabled = (
+    slug: string,
+    difficultyVariantsEnabled: boolean,
+) => {
+    return prisma.game.update({
+        where: { slug },
+        data: {
+            difficultyVariantsEnabled,
+        },
+    });
 };
 
 export const updateRacetimeCategory = (

--- a/api/src/database/games/Games.ts
+++ b/api/src/database/games/Games.ts
@@ -7,7 +7,9 @@ export const allGames = async (user?: string) => {
         include: {
             owners: { select: { id: true } },
             moderators: { select: { id: true } },
-            difficultyVariants: { select: { name: true, goalAmounts: true } },
+            difficultyVariants: {
+                select: { id: true, name: true, goalAmounts: true },
+            },
         },
     });
     if (user) {
@@ -36,7 +38,9 @@ export const gameForSlug = (slug: string) => {
             moderators: {
                 select: { id: true, username: true },
             },
-            difficultyVariants: { select: { name: true, goalAmounts: true } },
+            difficultyVariants: {
+                select: { id: true, name: true, goalAmounts: true },
+            },
         },
     });
 };
@@ -111,6 +115,18 @@ export const updateDifficultyVariantsEnabled = (
         where: { slug },
         data: {
             difficultyVariantsEnabled,
+        },
+    });
+};
+
+export const updateDifficultyGroups = (
+    slug: string,
+    difficultyGroups: number,
+) => {
+    return prisma.game.update({
+        where: { slug },
+        data: {
+            difficultyGroups,
         },
     });
 };
@@ -204,5 +220,39 @@ export const unfavoriteGame = async (slug: string, user: string) => {
     return prisma.user.update({
         where: { id: user },
         data: { favoritedGames: { disconnect: { slug } } },
+    });
+};
+
+export const createDifficultyVariant = (
+    slug: string,
+    name: string,
+    goalAmounts: number[],
+) => {
+    return prisma.difficultyVariant.create({
+        data: {
+            name,
+            goalAmounts,
+            game: { connect: { slug } },
+        },
+    });
+};
+
+export const updateDifficultyVariant = (
+    id: string,
+    name: string,
+    goalAmounts: number[],
+) => {
+    return prisma.difficultyVariant.update({
+        where: { id: id },
+        data: {
+            name,
+            goalAmounts,
+        },
+    });
+};
+
+export const deleteDifficultyVariant = (id: string) => {
+    return prisma.difficultyVariant.delete({
+        where: { id: id },
     });
 };

--- a/api/src/database/games/Games.ts
+++ b/api/src/database/games/Games.ts
@@ -256,3 +256,12 @@ export const deleteDifficultyVariant = (id: string) => {
         where: { id: id },
     });
 };
+
+export const getDifficultyVariant = (id: string) => {
+    return prisma.difficultyVariant.findUnique({ where: { id } });
+};
+
+export const getDifficultyGroupCount = async (slug: string) => {
+    return (await prisma.game.findUnique({ where: { slug } }))
+        ?.difficultyGroups;
+};

--- a/api/src/routes/games/Games.ts
+++ b/api/src/routes/games/Games.ts
@@ -11,6 +11,7 @@ import {
     removeModerator,
     removeOwner,
     unfavoriteGame,
+    updateDifficultyVariantsEnabled,
     updateGameCover,
     updateGameName,
     updateRacetimeCategory,
@@ -70,8 +71,14 @@ games.post('/', async (req, res) => {
 
 games.post('/:slug', async (req, res) => {
     const { slug } = req.params;
-    const { name, coverImage, enableSRLv5, racetimeCategory, racetimeGoal } =
-        req.body;
+    const {
+        name,
+        coverImage,
+        enableSRLv5,
+        racetimeCategory,
+        racetimeGoal,
+        difficultyVariantsEnabled,
+    } = req.body;
 
     let result = undefined;
     if (name) {
@@ -88,6 +95,12 @@ games.post('/:slug', async (req, res) => {
     }
     if (racetimeGoal) {
         result = await updateRacetimeGoal(slug, racetimeGoal);
+    }
+    if (difficultyVariantsEnabled !== undefined) {
+        result = await updateDifficultyVariantsEnabled(
+            slug,
+            difficultyVariantsEnabled,
+        );
     }
 
     if (!result) {

--- a/api/src/routes/games/Games.ts
+++ b/api/src/routes/games/Games.ts
@@ -3,7 +3,9 @@ import {
     addModerators,
     addOwners,
     allGames,
+    createDifficultyVariant,
     createGame,
+    deleteDifficultyVariant,
     favoriteGame,
     gameForSlug,
     isModerator,
@@ -11,6 +13,8 @@ import {
     removeModerator,
     removeOwner,
     unfavoriteGame,
+    updateDifficultyGroups,
+    updateDifficultyVariant,
     updateDifficultyVariantsEnabled,
     updateGameCover,
     updateGameName,
@@ -78,6 +82,7 @@ games.post('/:slug', async (req, res) => {
         racetimeCategory,
         racetimeGoal,
         difficultyVariantsEnabled,
+        difficultyGroups,
     } = req.body;
 
     let result = undefined;
@@ -101,6 +106,9 @@ games.post('/:slug', async (req, res) => {
             slug,
             difficultyVariantsEnabled,
         );
+    }
+    if (difficultyGroups) {
+        result = await updateDifficultyGroups(slug, difficultyGroups);
     }
 
     if (!result) {
@@ -350,6 +358,61 @@ games.delete('/:slug/favorite', (req, res) => {
     unfavoriteGame(slug, req.session.user);
 
     res.sendStatus(200);
+});
+
+games.post('/:slug/difficultyVariants', async (req, res) => {
+    if (!req.session.user) {
+        res.sendStatus(401);
+        return;
+    }
+
+    const { slug } = req.params;
+
+    if (!slug || !(await isOwner(slug, req.session.user))) {
+        res.sendStatus(403);
+        return;
+    }
+
+    const { name, goalAmounts } = req.body;
+
+    const result = await createDifficultyVariant(slug, name, goalAmounts);
+
+    res.status(200).send(result);
+});
+
+games.post('/:slug/difficultyVariants/:id', async (req, res) => {
+    if (!req.session.user) {
+        res.sendStatus(401);
+        return;
+    }
+
+    const { slug, id } = req.params;
+    if (!slug || !(await isOwner(slug, req.session.user))) {
+        res.sendStatus(403);
+        return;
+    }
+
+    const { name, goalAmounts } = req.body;
+
+    const result = await updateDifficultyVariant(id, name, goalAmounts);
+
+    res.status(200).send(result);
+});
+
+games.delete('/:slug/difficultyVariants/:id', async (req, res) => {
+    if (!req.session.user) {
+        res.sendStatus(401);
+        return;
+    }
+
+    const { slug, id } = req.params;
+    if (!slug || !(await isOwner(slug, req.session.user))) {
+        res.sendStatus(403);
+        return;
+    }
+
+    const result = await deleteDifficultyVariant(id);
+    res.status(200).send(result);
 });
 
 export default games;

--- a/api/src/routes/rooms/Rooms.ts
+++ b/api/src/routes/rooms/Rooms.ts
@@ -1,7 +1,10 @@
 import { randomInt } from 'crypto';
 import { Router } from 'express';
 import { createRoomToken } from '../../auth/RoomAuth';
-import Room, { BoardGenerationMode } from '../../core/Room';
+import Room, {
+    BoardGenerationMode,
+    BoardGenerationOptions,
+} from '../../core/Room';
 import { allRooms } from '../../core/RoomServer';
 import {
     createRoom,
@@ -11,6 +14,7 @@ import {
 import { gameForSlug, goalCount } from '../../database/games/Games';
 import { chunk } from '../../util/Array';
 import actions from './Actions';
+import { logWarn } from '../../Logger';
 
 const MIN_ROOM_GOALS_REQUIRED = 25;
 const rooms = Router();
@@ -56,6 +60,7 @@ rooms.post('/', async (req, res) => {
         nickname,
         password,
         /*variant, mode,*/ generationMode,
+        difficulty,
     } = req.body;
 
     if (!name || !game || !nickname /*|| !variant || !mode*/) {
@@ -95,14 +100,30 @@ rooms.post('/', async (req, res) => {
             !!gameData.racetimeCategory &&
             !!gameData.racetimeGoal,
     );
-    let genMode;
+    const genMode: BoardGenerationOptions = {
+        mode: BoardGenerationMode.RANDOM,
+    } as BoardGenerationOptions; // necessary cast to avoid auto-narrowing
+    let useDefault = true;
     if (generationMode) {
-        genMode = generationMode;
-    } else {
-        if (gameData.enableSRLv5) {
-            genMode = BoardGenerationMode.SRLv5;
+        genMode.mode = generationMode as BoardGenerationMode;
+        if (genMode.mode === BoardGenerationMode.DIFFICULTY) {
+            if (difficulty) {
+                genMode.difficulty = difficulty;
+                useDefault = false;
+            } else {
+                logWarn(
+                    `Unable to generate using dificulty variants for ${slug}, falling back to default mode.`,
+                );
+            }
         } else {
-            genMode = BoardGenerationMode.RANDOM;
+            useDefault = false;
+        }
+    }
+    if (useDefault) {
+        if (gameData.enableSRLv5) {
+            genMode.mode = BoardGenerationMode.SRLv5;
+        } else {
+            genMode.mode = BoardGenerationMode.RANDOM;
         }
     }
     await room.generateBoard(genMode);

--- a/api/src/types/Game.d.ts
+++ b/api/src/types/Game.d.ts
@@ -31,6 +31,7 @@ export interface User {
   racetimeConnected?: boolean;
 }
 export interface DifficultyVariant {
+  id?: string;
   name: string;
   goalAmounts?: number[];
 }

--- a/api/src/types/Game.d.ts
+++ b/api/src/types/Game.d.ts
@@ -22,6 +22,7 @@ export interface Game {
   racetimeGoal?: string;
   difficultyVariantsEnabled?: boolean;
   difficultyVariants?: DifficultyVariant[];
+  difficultyGroups?: number;
 }
 export interface User {
   id: string;

--- a/api/src/types/Game.d.ts
+++ b/api/src/types/Game.d.ts
@@ -20,10 +20,16 @@ export interface Game {
   racetimeBeta?: boolean;
   racetimeCategory?: string;
   racetimeGoal?: string;
+  difficultyVariantsEnabled?: boolean;
+  difficultyVariants?: DifficultyVariant[];
 }
 export interface User {
   id: string;
   username: string;
   staff: boolean;
   racetimeConnected?: boolean;
+}
+export interface DifficultyVariant {
+  name: string;
+  goalAmounts?: number[];
 }

--- a/api/src/types/RoomAction.d.ts
+++ b/api/src/types/RoomAction.d.ts
@@ -60,6 +60,9 @@ export interface ChangeColorAction {
 }
 export interface NewCardAction {
   action: "newCard";
-  seed?: number;
-  generationMode?: string;
+  options?: {
+    seed?: number;
+    mode: string;
+    difficulty?: string;
+  };
 }

--- a/schema/schemas/Game.json
+++ b/schema/schemas/Game.json
@@ -15,6 +15,19 @@
         "enableSRLv5": {"type": "boolean"},
         "racetimeBeta": {"type": "boolean"},
         "racetimeCategory": {"type": "string"},
-        "racetimeGoal": {"type": "string"}
+        "racetimeGoal": {"type": "string"},
+        "difficultyVariantsEnabled": {"type": "boolean"},
+        "difficultyVariants": {"type": "array", "items": {"$ref": "#/$defs/DifficultyVariant" }}
+    },
+    "$defs": {
+        "DifficultyVariant": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name"],
+            "properties": {
+                "name": {"type": "string"},
+                "goalAmounts": {"type": "array", "items": {"type": "number"}}
+            }
+        }
     }
 }

--- a/schema/schemas/Game.json
+++ b/schema/schemas/Game.json
@@ -26,6 +26,7 @@
             "additionalProperties": false,
             "required": ["name"],
             "properties": {
+                "id": {"type": "string"},
                 "name": {"type": "string"},
                 "goalAmounts": {"type": "array", "items": {"type": "number"}}
             }

--- a/schema/schemas/Game.json
+++ b/schema/schemas/Game.json
@@ -17,7 +17,8 @@
         "racetimeCategory": {"type": "string"},
         "racetimeGoal": {"type": "string"},
         "difficultyVariantsEnabled": {"type": "boolean"},
-        "difficultyVariants": {"type": "array", "items": {"$ref": "#/$defs/DifficultyVariant" }}
+        "difficultyVariants": {"type": "array", "items": {"$ref": "#/$defs/DifficultyVariant" }},
+        "difficultyGroups": {"type": "number"}
     },
     "$defs": {
         "DifficultyVariant": {

--- a/schema/schemas/RoomAction.json
+++ b/schema/schemas/RoomAction.json
@@ -101,8 +101,15 @@
             "additionalProperties": false,
             "properties": {
                 "action": "newCard",
-                "seed": {"type": "number"},
-                "generationMode": {"type": "string"}
+                "options": {
+                        "required": ["mode"],
+                        "additionalProperties": false,
+                        "properties": {
+                            "seed": {"type": "number"},
+                            "mode": {"type": "string"},
+                            "difficulty": {"type": "string"}
+                    }
+                }
             }
         }
     }

--- a/schema/types/Game.d.ts
+++ b/schema/types/Game.d.ts
@@ -31,6 +31,7 @@ export interface User {
   racetimeConnected?: boolean;
 }
 export interface DifficultyVariant {
+  id?: string;
   name: string;
   goalAmounts?: number[];
 }

--- a/schema/types/Game.d.ts
+++ b/schema/types/Game.d.ts
@@ -22,6 +22,7 @@ export interface Game {
   racetimeGoal?: string;
   difficultyVariantsEnabled?: boolean;
   difficultyVariants?: DifficultyVariant[];
+  difficultyGroups?: number;
 }
 export interface User {
   id: string;

--- a/schema/types/Game.d.ts
+++ b/schema/types/Game.d.ts
@@ -20,10 +20,16 @@ export interface Game {
   racetimeBeta?: boolean;
   racetimeCategory?: string;
   racetimeGoal?: string;
+  difficultyVariantsEnabled?: boolean;
+  difficultyVariants?: DifficultyVariant[];
 }
 export interface User {
   id: string;
   username: string;
   staff: boolean;
   racetimeConnected?: boolean;
+}
+export interface DifficultyVariant {
+  name: string;
+  goalAmounts?: number[];
 }

--- a/schema/types/RoomAction.d.ts
+++ b/schema/types/RoomAction.d.ts
@@ -60,6 +60,9 @@ export interface ChangeColorAction {
 }
 export interface NewCardAction {
   action: "newCard";
-  seed?: number;
-  generationMode?: string;
+  options?: {
+    seed?: number;
+    mode: string;
+    difficulty?: string;
+  };
 }

--- a/web/src/app/(main)/games/[slug]/page.tsx
+++ b/web/src/app/(main)/games/[slug]/page.tsx
@@ -11,6 +11,7 @@ import PermissionsManagement from '../../../../components/game/PermissionsManage
 import GoalManagement from '../../../../components/game/goals/GoalManagement';
 import { GoalManagerContextProvider } from '../../../../context/GoalManagerContext';
 import { alertError } from '../../../../lib/Utils';
+import Variants from '../../../../components/game/Variants';
 
 export default function GamePage({
     params: { slug },
@@ -48,6 +49,9 @@ export default function GamePage({
 
     const tabs = ['Goals'];
     if (isOwner) {
+        if (gameData.difficultyVariantsEnabled) {
+            tabs.push('Variants');
+        }
         tabs.push('Permissions');
         tabs.push('Settings');
     }
@@ -123,6 +127,9 @@ export default function GamePage({
                     >
                         <GoalManagement />
                     </GoalManagerContextProvider>
+                </TabPanel>
+                <TabPanel value="Variants">
+                    <Variants gameData={gameData} />
                 </TabPanel>
                 <TabPanel value="Permissions">
                     <PermissionsManagement slug={slug} gameData={gameData} />

--- a/web/src/components/game/GameSettings.tsx
+++ b/web/src/components/game/GameSettings.tsx
@@ -115,6 +115,8 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                     enableSRLv5: gameData.enableSRLv5,
                     racetimeCategory: gameData.racetimeCategory,
                     racetimeGoal: gameData.racetimeGoal,
+                    difficultyVariantsEnabled:
+                        gameData.difficultyVariantsEnabled,
                 }}
                 onSubmit={async ({
                     name,
@@ -122,6 +124,7 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                     enableSRLv5,
                     racetimeCategory,
                     racetimeGoal,
+                    difficultyVariantsEnabled,
                 }) => {
                     const res = await fetch(`/api/games/${gameData.slug}`, {
                         method: 'POST',
@@ -134,6 +137,7 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                             enableSRLv5,
                             racetimeCategory,
                             racetimeGoal,
+                            difficultyVariantsEnabled,
                         }),
                     });
                     if (!res.ok) {
@@ -179,6 +183,25 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                                     value. It also tries to minimize synergy
                                     between goals in the same line by minimizing
                                     the category overlap.
+                                </Typography>
+                            </HoverIcon>
+                        </Box>
+                        <Box display="flex" alignItems="center">
+                            <FormikSwitch
+                                id="game-difficulty-variants-switch"
+                                label="Enable Difficulty Variants"
+                                name="difficultyVariantsEnabled"
+                            />
+                            <HoverIcon icon={<Info />}>
+                                <Typography variant="caption">
+                                    Difficulty varaints are a special type of
+                                    variants that modify generation instead of
+                                    the goal list. Difficulty variants modify
+                                    how many goals from a given difficulty are
+                                    selected during generation, which can impact
+                                    the difficulty or length of the final board.
+                                    When a difficulty variant is chosen, only
+                                    the Random generation mode is available.
                                 </Typography>
                             </HoverIcon>
                         </Box>

--- a/web/src/components/game/GameSettings.tsx
+++ b/web/src/components/game/GameSettings.tsx
@@ -23,6 +23,7 @@ import { Game } from '../../types/Game';
 import HoverIcon from '../HoverIcon';
 import FormikSwitch from '../input/FormikSwitch';
 import FormikTextField from '../input/FormikTextField';
+import NumberInput from '../input/NumberInput';
 
 async function validateRacetimeCategory(value: string) {
     if (value) {
@@ -117,6 +118,7 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                     racetimeGoal: gameData.racetimeGoal,
                     difficultyVariantsEnabled:
                         gameData.difficultyVariantsEnabled,
+                    difficultyGroups: gameData.difficultyGroups ?? 0,
                 }}
                 onSubmit={async ({
                     name,
@@ -125,6 +127,7 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                     racetimeCategory,
                     racetimeGoal,
                     difficultyVariantsEnabled,
+                    difficultyGroups,
                 }) => {
                     const res = await fetch(`/api/games/${gameData.slug}`, {
                         method: 'POST',
@@ -138,6 +141,7 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                             racetimeCategory,
                             racetimeGoal,
                             difficultyVariantsEnabled,
+                            difficultyGroups,
                         }),
                     });
                     if (!res.ok) {
@@ -186,24 +190,57 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                                 </Typography>
                             </HoverIcon>
                         </Box>
-                        <Box display="flex" alignItems="center">
-                            <FormikSwitch
-                                id="game-difficulty-variants-switch"
-                                label="Enable Difficulty Variants"
-                                name="difficultyVariantsEnabled"
-                            />
-                            <HoverIcon icon={<Info />}>
-                                <Typography variant="caption">
-                                    Difficulty varaints are a special type of
-                                    variants that modify generation instead of
-                                    the goal list. Difficulty variants modify
-                                    how many goals from a given difficulty are
-                                    selected during generation, which can impact
-                                    the difficulty or length of the final board.
-                                    When a difficulty variant is chosen, only
-                                    the Random generation mode is available.
-                                </Typography>
-                            </HoverIcon>
+                        <Box display="flex" alignItems="center" columnGap={3}>
+                            <Box display="flex" alignItems="center">
+                                <FormikSwitch
+                                    id="game-difficulty-variants-switch"
+                                    label="Enable Difficulty Variants"
+                                    name="difficultyVariantsEnabled"
+                                />
+                                <HoverIcon icon={<Info />}>
+                                    <Typography variant="caption">
+                                        Difficulty varaints are a special type
+                                        of variants that modify generation
+                                        instead of the goal list. Difficulty
+                                        variants modify how many goals from a
+                                        given difficulty are selected during
+                                        generation, which can impact the
+                                        difficulty or length of the final board.
+                                        When a difficulty variant is chosen,
+                                        only the Random generation mode is
+                                        available.
+                                    </Typography>
+                                </HoverIcon>
+                            </Box>
+                            <Box
+                                display="flex"
+                                alignItems="center"
+                                columnGap={1}
+                            >
+                                <NumberInput
+                                    name="difficultyGroups"
+                                    label="Difficulty Groups"
+                                    min={0}
+                                    max={25}
+                                />
+                                <HoverIcon icon={<Info />}>
+                                    <Typography variant="caption">
+                                        Difficulty groups is the number of
+                                        groups goals are grouped into for
+                                        generating a board for a difficulty
+                                        variant. The available goal difficulties
+                                        will be split into equal sized groups
+                                        based on this number. For example, if
+                                        there are 5 groups and 25 difficulties,
+                                        every 5 difficulties would be a group
+                                        (1-5, 6-10, etc.). Setting this to 0 is
+                                        equivalent to disabling difficulty
+                                        variants, as the generator will be
+                                        unable to generate a board with 0
+                                        groups.
+                                    </Typography>
+                                </HoverIcon>
+                            </Box>
                         </Box>
                         {gameData.racetimeBeta && <RacetimeSettings />}
                         <Box pt={1} display="flex">

--- a/web/src/components/game/Variants.tsx
+++ b/web/src/components/game/Variants.tsx
@@ -4,12 +4,6 @@ import {
     IconButton,
     List,
     ListItem,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
     Typography,
 } from '@mui/material';
 import { DifficultyVariant, Game } from '../../types/Game';
@@ -17,19 +11,24 @@ import Add from '@mui/icons-material/Add';
 import Edit from '@mui/icons-material/Edit';
 import Check from '@mui/icons-material/Check';
 import Close from '@mui/icons-material/Close';
+import Delete from '@mui/icons-material/Delete';
 import { FieldArray, Form, Formik } from 'formik';
 import FormikTextField from '../input/FormikTextField';
 import NumberInput from '../input/NumberInput';
 import { useState } from 'react';
 import { useList } from 'react-use';
+import { mutate } from 'swr';
+import { alertError } from '../../lib/Utils';
 
 interface DifficultyVariantEditRowProps {
+    slug: string;
     variant: DifficultyVariant;
     disabled: boolean;
     done: () => void;
 }
 
 function DificultyVariantEditRow({
+    slug,
     variant,
     disabled,
     done,
@@ -37,7 +36,30 @@ function DificultyVariantEditRow({
     return (
         <Formik
             initialValues={{ ...variant }}
-            onSubmit={() => {
+            onSubmit={async ({ name, goalAmounts }) => {
+                let res: Response;
+                if (variant.id) {
+                    res = await fetch(
+                        `/api/games/${slug}/difficultyVariants/${variant.id}`,
+                        {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ name, goalAmounts }),
+                        },
+                    );
+                } else {
+                    res = await fetch(`/api/games/${slug}/difficultyVariants`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ name, goalAmounts }),
+                    });
+                }
+
+                if (!res.ok) {
+                    alertError(`Unable to save difficulty variant`);
+                    return;
+                }
+                mutate(`/api/games/${slug}`);
                 done();
             }}
             validateOnChange={false}
@@ -92,10 +114,11 @@ function DificultyVariantEditRow({
 }
 
 interface DificultyVariantRow {
+    slug: string;
     variant: DifficultyVariant;
 }
 
-function DifficultyVariantRow({ variant }: DificultyVariantRow) {
+function DifficultyVariantRow({ slug, variant }: DificultyVariantRow) {
     const [edit, setEdit] = useState(false);
 
     return (
@@ -108,6 +131,7 @@ function DifficultyVariantRow({ variant }: DificultyVariantRow) {
         >
             <Box display="flex" columnGap={1} alignItems="center">
                 <DificultyVariantEditRow
+                    slug={slug}
                     variant={variant}
                     disabled={!edit}
                     done={() => setEdit(false)}
@@ -117,6 +141,26 @@ function DifficultyVariantRow({ variant }: DificultyVariantRow) {
                         <Edit />
                     </IconButton>
                 )}
+                <IconButton
+                    edge="end"
+                    onClick={async () => {
+                        const res = await fetch(
+                            `/api/games/${slug}/difficultyVariants/${variant.id}`,
+                            {
+                                method: 'DELETE',
+                                headers: { 'Content-Type': 'application/json' },
+                            },
+                        );
+
+                        if (!res.ok) {
+                            alertError(`Unable to delete difficulty variant`);
+                            return;
+                        }
+                        mutate(`/api/games/${slug}`);
+                    }}
+                >
+                    <Delete />
+                </IconButton>
             </Box>
         </ListItem>
     );
@@ -127,35 +171,88 @@ interface VariantsProps {
 }
 
 export default function Variants({ gameData }: VariantsProps) {
-    const [difficultyVariants, { push }] = useList<DifficultyVariant>(
-        gameData.difficultyVariants ?? [],
-    );
-    if (!gameData.difficultyVariantsEnabled) {
+    if (!gameData.difficultyVariantsEnabled || !gameData.difficultyVariants) {
         return null;
     }
+
+    console.log('render');
 
     return (
         <>
             <Typography variant="h6">Difficulty Variants</Typography>
             <List>
-                {difficultyVariants.map((variant) => (
+                {gameData.difficultyVariants.map((variant) => (
                     <DifficultyVariantRow
-                        key={variant.name}
+                        key={variant.id}
+                        slug={gameData.slug}
                         variant={variant}
                     />
                 ))}
-            </List>
-
-            <Box>
-                <Button
-                    startIcon={<Add />}
-                    onClick={() => {
-                        push({ name: '', goalAmounts: [0, 0, 0, 0] });
+                <Formik
+                    initialValues={{
+                        name: '',
+                        goalAmounts: Array(gameData.difficultyGroups).fill(0),
                     }}
+                    onSubmit={async ({ name, goalAmounts }) => {
+                        const res = await fetch(
+                            `/api/games/${gameData.slug}/difficultyVariants`,
+                            {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ name, goalAmounts }),
+                            },
+                        );
+
+                        if (!res.ok) {
+                            alertError(`Unable to save difficulty variant`);
+                            return;
+                        }
+                        mutate(`/api/games/${gameData.slug}`);
+                    }}
+                    validateOnChange={false}
                 >
-                    Add Variant
-                </Button>
-            </Box>
+                    {({ values, resetForm }) => (
+                        <Form>
+                            <Box
+                                display="flex"
+                                columnGap={1}
+                                alignItems="center"
+                            >
+                                <FormikTextField name="name" label="Name" />
+                                <FieldArray name="goalAmounts">
+                                    {() =>
+                                        values.goalAmounts?.map((_, index) => (
+                                            <NumberInput
+                                                key={index}
+                                                name={`goalAmounts.${index}`}
+                                                label={`${index + 1}`}
+                                                min={0}
+                                                max={25}
+                                            />
+                                        ))
+                                    }
+                                </FieldArray>
+                                <IconButton
+                                    edge="end"
+                                    onClick={() => {
+                                        resetForm();
+                                    }}
+                                    color="error"
+                                >
+                                    <Close />
+                                </IconButton>
+                                <IconButton
+                                    type="submit"
+                                    edge="end"
+                                    color="success"
+                                >
+                                    <Check />
+                                </IconButton>
+                            </Box>
+                        </Form>
+                    )}
+                </Formik>
+            </List>
         </>
     );
 }

--- a/web/src/components/game/Variants.tsx
+++ b/web/src/components/game/Variants.tsx
@@ -1,0 +1,161 @@
+import {
+    Box,
+    Button,
+    IconButton,
+    List,
+    ListItem,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Typography,
+} from '@mui/material';
+import { DifficultyVariant, Game } from '../../types/Game';
+import Add from '@mui/icons-material/Add';
+import Edit from '@mui/icons-material/Edit';
+import Check from '@mui/icons-material/Check';
+import Close from '@mui/icons-material/Close';
+import { FieldArray, Form, Formik } from 'formik';
+import FormikTextField from '../input/FormikTextField';
+import NumberInput from '../input/NumberInput';
+import { useState } from 'react';
+import { useList } from 'react-use';
+
+interface DifficultyVariantEditRowProps {
+    variant: DifficultyVariant;
+    disabled: boolean;
+    done: () => void;
+}
+
+function DificultyVariantEditRow({
+    variant,
+    disabled,
+    done,
+}: DifficultyVariantEditRowProps) {
+    return (
+        <Formik
+            initialValues={{ ...variant }}
+            onSubmit={() => {
+                done();
+            }}
+            validateOnChange={false}
+        >
+            {({ resetForm }) => (
+                <Form>
+                    <Box display="flex" columnGap={1} alignItems="center">
+                        <FormikTextField
+                            name="name"
+                            label="Name"
+                            disabled={disabled}
+                        />
+                        <FieldArray name="goalAmounts">
+                            {() =>
+                                variant.goalAmounts?.map((_, index) => (
+                                    <NumberInput
+                                        key={index}
+                                        name={`goalAmounts.${index}`}
+                                        label={`${index}`}
+                                        min={0}
+                                        max={25}
+                                        disabled={disabled}
+                                    />
+                                ))
+                            }
+                        </FieldArray>
+                        {!disabled && (
+                            <>
+                                <IconButton
+                                    edge="end"
+                                    onClick={() => {
+                                        resetForm(), done();
+                                    }}
+                                    color="error"
+                                >
+                                    <Close />
+                                </IconButton>
+                                <IconButton
+                                    type="submit"
+                                    edge="end"
+                                    color="success"
+                                >
+                                    <Check />
+                                </IconButton>
+                            </>
+                        )}
+                    </Box>
+                </Form>
+            )}
+        </Formik>
+    );
+}
+
+interface DificultyVariantRow {
+    variant: DifficultyVariant;
+}
+
+function DifficultyVariantRow({ variant }: DificultyVariantRow) {
+    const [edit, setEdit] = useState(false);
+
+    return (
+        <ListItem
+            key={variant.name}
+            sx={{
+                borderBottom: 1,
+                borderColor: (theme) => theme.palette.divider,
+            }}
+        >
+            <Box display="flex" columnGap={1} alignItems="center">
+                <DificultyVariantEditRow
+                    variant={variant}
+                    disabled={!edit}
+                    done={() => setEdit(false)}
+                />
+                {!edit && (
+                    <IconButton edge="end" onClick={() => setEdit(true)}>
+                        <Edit />
+                    </IconButton>
+                )}
+            </Box>
+        </ListItem>
+    );
+}
+
+interface VariantsProps {
+    gameData: Game;
+}
+
+export default function Variants({ gameData }: VariantsProps) {
+    const [difficultyVariants, { push }] = useList<DifficultyVariant>(
+        gameData.difficultyVariants ?? [],
+    );
+    if (!gameData.difficultyVariantsEnabled) {
+        return null;
+    }
+
+    return (
+        <>
+            <Typography variant="h6">Difficulty Variants</Typography>
+            <List>
+                {difficultyVariants.map((variant) => (
+                    <DifficultyVariantRow
+                        key={variant.name}
+                        variant={variant}
+                    />
+                ))}
+            </List>
+
+            <Box>
+                <Button
+                    startIcon={<Add />}
+                    onClick={() => {
+                        push({ name: '', goalAmounts: [0, 0, 0, 0] });
+                    }}
+                >
+                    Add Variant
+                </Button>
+            </Box>
+        </>
+    );
+}

--- a/web/src/components/input/FormikSwitch.tsx
+++ b/web/src/components/input/FormikSwitch.tsx
@@ -13,7 +13,7 @@ export default function FormikSwitch({ id, name, label }: FormikSwitchProps) {
         <FormControlLabel
             control={
                 <Switch
-                    value={field.value}
+                    checked={field.value}
                     onChange={(e) => helpers.setValue(e.target.checked)}
                     onBlur={field.onBlur}
                 />

--- a/web/src/types/Game.d.ts
+++ b/web/src/types/Game.d.ts
@@ -31,6 +31,7 @@ export interface User {
   racetimeConnected?: boolean;
 }
 export interface DifficultyVariant {
+  id?: string;
   name: string;
   goalAmounts?: number[];
 }

--- a/web/src/types/Game.d.ts
+++ b/web/src/types/Game.d.ts
@@ -22,6 +22,7 @@ export interface Game {
   racetimeGoal?: string;
   difficultyVariantsEnabled?: boolean;
   difficultyVariants?: DifficultyVariant[];
+  difficultyGroups?: number;
 }
 export interface User {
   id: string;

--- a/web/src/types/Game.d.ts
+++ b/web/src/types/Game.d.ts
@@ -20,10 +20,16 @@ export interface Game {
   racetimeBeta?: boolean;
   racetimeCategory?: string;
   racetimeGoal?: string;
+  difficultyVariantsEnabled?: boolean;
+  difficultyVariants?: DifficultyVariant[];
 }
 export interface User {
   id: string;
   username: string;
   staff: boolean;
   racetimeConnected?: boolean;
+}
+export interface DifficultyVariant {
+  name: string;
+  goalAmounts?: number[];
 }

--- a/web/src/types/RoomAction.d.ts
+++ b/web/src/types/RoomAction.d.ts
@@ -60,6 +60,9 @@ export interface ChangeColorAction {
 }
 export interface NewCardAction {
   action: "newCard";
-  seed?: number;
-  generationMode?: string;
+  options?: {
+    seed?: number;
+    mode: string;
+    difficulty?: string;
+  };
 }


### PR DESCRIPTION
Introduces the concept of difficulty variants, PlayBingo's first variant mode. Difficulty variants capture variant play modes where the underlying goal list has no changes, but instead the generation mechanism changes. These variants can be used to change the easier or harder boards, as well as create shorter or longer boards.

Included in this development
- New data model elements for difficulty variants
- Settings toggle for each game to enable this functionality (off by default)
- Variant editor
- Variant based generation

Currently, difficulty variant generation only supports the random board generation mode. Future development may allow other generation mechanisms.