### PR TITLE
Add Ability to Hide Card in Room Initially

### DIFF
--- a/api/prisma/migrations/20241201010208_add_hide_card/migration.sql
+++ b/api/prisma/migrations/20241201010208_add_hide_card/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Room" ADD COLUMN     "hideCard" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -117,6 +117,7 @@ model Room {
   gameId       String?
   board        String[]
   racetimeRoom String?
+  hideCard     Boolean      @default(false)
 }
 
 model RoomAction {

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -101,6 +101,7 @@ export default class Room {
         slug: string,
         password: string,
         id: string,
+        hideCard: boolean,
         racetimeEligible: boolean,
         racetimeUrl?: string,
     ) {
@@ -128,7 +129,7 @@ export default class Room {
             this.racetimeHandler.connect(racetimeUrl);
         }
 
-        this.hideCard = true;
+        this.hideCard = hideCard;
     }
 
     async generateBoard(options: BoardGenerationOptions) {

--- a/api/src/core/RoomServer.ts
+++ b/api/src/core/RoomServer.ts
@@ -102,6 +102,12 @@ roomWebSocketServer.on('connection', (ws, req) => {
             case 'newCard':
                 room.handleNewCard(action);
                 break;
+            case 'revealCard':
+                const board = room.handleRevealCard(payload);
+                if (board) {
+                    ws.send(JSON.stringify({ action: 'syncBoard', board }));
+                }
+                break;
         }
     });
     ws.on('close', () => {

--- a/api/src/database/Rooms.ts
+++ b/api/src/database/Rooms.ts
@@ -8,6 +8,7 @@ export const createRoom = (
     game: string,
     isPrivate: boolean,
     password: string,
+    hideCard: boolean,
 ) => {
     return prisma.room.create({
         data: {
@@ -16,6 +17,7 @@ export const createRoom = (
             private: isPrivate,
             game: { connect: { id: game } },
             password,
+            hideCard,
         },
     });
 };

--- a/api/src/routes/rooms/Rooms.ts
+++ b/api/src/routes/rooms/Rooms.ts
@@ -48,6 +48,7 @@ rooms.post('/', async (req, res) => {
         password,
         /*variant, mode,*/ generationMode,
         difficulty,
+        hideCard,
     } = req.body;
 
     if (!name || !game || !nickname /*|| !variant || !mode*/) {
@@ -78,7 +79,14 @@ rooms.post('/', async (req, res) => {
     const num = randomInt(1000, 10000);
     const slug = `${adj}-${noun}-${num}`;
 
-    const dbRoom = await createRoom(slug, name, gameData.id, false, password);
+    const dbRoom = await createRoom(
+        slug,
+        name,
+        gameData.id,
+        false,
+        password,
+        hideCard,
+    );
     const room = new Room(
         name,
         gameData.name,
@@ -86,6 +94,7 @@ rooms.post('/', async (req, res) => {
         slug,
         password,
         dbRoom.id,
+        hideCard,
         gameData.racetimeBeta &&
             !!gameData.racetimeCategory &&
             !!gameData.racetimeGoal,
@@ -142,6 +151,7 @@ rooms.get('/:slug', async (req, res) => {
         dbRoom.slug,
         dbRoom.password ?? '',
         dbRoom.id,
+        dbRoom.hideCard,
         (dbRoom.game?.racetimeBeta &&
             !!dbRoom.game.racetimeCategory &&
             !!dbRoom.game.racetimeGoal) ||

--- a/api/src/types/Board.d.ts
+++ b/api/src/types/Board.d.ts
@@ -5,11 +5,11 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-/**
- * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
- */
-export interface Board {
+export type Board = RevealedBoard | HiddenBoard;
+
+export interface RevealedBoard {
   board: Cell[][];
+  hidden?: false;
 }
 /**
  * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
@@ -18,4 +18,7 @@ export interface Cell {
   goal: string;
   description: string;
   colors: string[];
+}
+export interface HiddenBoard {
+  hidden: true;
 }

--- a/api/src/types/RoomAction.d.ts
+++ b/api/src/types/RoomAction.d.ts
@@ -16,6 +16,7 @@ export type RoomAction = (
   | UnmarkAction
   | ChangeColorAction
   | NewCardAction
+  | RevealCardAction
 ) & {
   /**
    * JWT for the room obtained from the server
@@ -65,4 +66,7 @@ export interface NewCardAction {
     mode: string;
     difficulty?: string;
   };
+}
+export interface RevealCardAction {
+  action: "revealCard";
 }

--- a/api/src/types/ServerMessage.d.ts
+++ b/api/src/types/ServerMessage.d.ts
@@ -56,6 +56,7 @@ export type ChatMessage = (
       color: string;
     }
 )[];
+export type Board = RevealedBoard | HiddenBoard;
 
 /**
  * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
@@ -65,11 +66,12 @@ export interface Cell {
   description: string;
   colors: string[];
 }
-/**
- * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
- */
-export interface Board {
+export interface RevealedBoard {
   board: Cell[][];
+  hidden?: false;
+}
+export interface HiddenBoard {
+  hidden: true;
 }
 /**
  * Basic information about a room

--- a/schema/schemas/Board.json
+++ b/schema/schemas/Board.json
@@ -2,9 +2,25 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,
-    "required": ["board"],
-    "description": "An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action",
-    "properties": {
-        "board": {"type": "array", "items": {"type": "array", "items": {"$ref": "./Cell.json"}}}
+    "anyOf": [
+        {"$ref": "#/$defs/RevealedBoard"},
+        {"$ref": "#/$defs/HiddenBoard"}
+    ],
+    "$defs": {
+        "RevealedBoard": {
+            "additionalProperties": false,
+            "required": ["board"],
+            "properties": {
+                "board": {"type": "array", "items": {"type": "array", "items": {"$ref": "./Cell.json"}}},
+                "hidden": { "enum": [ false ]}
+            }
+        },
+        "HiddenBoard": {
+            "additionalProperties": false,
+            "required": ["hidden"],
+            "properties": {
+                "hidden": { "enum": [ true ]}
+            }
+        }
     }
 }

--- a/schema/schemas/RoomAction.json
+++ b/schema/schemas/RoomAction.json
@@ -14,7 +14,8 @@
         {"$ref": "#/$defs/MarkAction"},
         {"$ref": "#/$defs/UnmarkAction"},
         {"$ref": "#/$defs/ChangeColorAction"},
-        {"$ref": "#/$defs/NewCardAction"}
+        {"$ref": "#/$defs/NewCardAction"},
+        {"$ref": "#/$defs/RevealCardAction"}
     ],
     "$defs": {
         "JoinAction": {
@@ -110,6 +111,13 @@
                             "difficulty": {"type": "string"}
                     }
                 }
+            }
+        },
+        "RevealCardAction": {
+            "required": ["action"],
+            "additionalProperties": false,
+            "properties": {
+                "action": "revealCard"
             }
         }
     }

--- a/schema/types/Board.d.ts
+++ b/schema/types/Board.d.ts
@@ -5,11 +5,11 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-/**
- * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
- */
-export interface Board {
+export type Board = RevealedBoard | HiddenBoard;
+
+export interface RevealedBoard {
   board: Cell[][];
+  hidden?: false;
 }
 /**
  * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
@@ -18,4 +18,7 @@ export interface Cell {
   goal: string;
   description: string;
   colors: string[];
+}
+export interface HiddenBoard {
+  hidden: true;
 }

--- a/schema/types/RoomAction.d.ts
+++ b/schema/types/RoomAction.d.ts
@@ -16,6 +16,7 @@ export type RoomAction = (
   | UnmarkAction
   | ChangeColorAction
   | NewCardAction
+  | RevealCardAction
 ) & {
   /**
    * JWT for the room obtained from the server
@@ -65,4 +66,7 @@ export interface NewCardAction {
     mode: string;
     difficulty?: string;
   };
+}
+export interface RevealCardAction {
+  action: "revealCard";
 }

--- a/schema/types/ServerMessage.d.ts
+++ b/schema/types/ServerMessage.d.ts
@@ -56,6 +56,7 @@ export type ChatMessage = (
       color: string;
     }
 )[];
+export type Board = RevealedBoard | HiddenBoard;
 
 /**
  * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
@@ -65,11 +66,12 @@ export interface Cell {
   description: string;
   colors: string[];
 }
-/**
- * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
- */
-export interface Board {
+export interface RevealedBoard {
   board: Cell[][];
+  hidden?: false;
+}
+export interface HiddenBoard {
+  hidden: true;
 }
 /**
  * Basic information about a room

--- a/web/src/components/RoomCreateForm.tsx
+++ b/web/src/components/RoomCreateForm.tsx
@@ -21,6 +21,7 @@ import * as yup from 'yup';
 import { useApi } from '../lib/Hooks';
 import FormikSelectFieldAutocomplete from './input/FormikSelectFieldAutocomplete';
 import FormikTextField from './input/FormikTextField';
+import FormikSwitch from './input/FormikSwitch';
 
 const roomValidationSchema = yup.object().shape({
     name: yup.string().required('Room name is required'),
@@ -164,6 +165,7 @@ export default function RoomCreateForm() {
                 seed: undefined,
                 generationMode: '',
                 difficulty: '',
+                hideCard: false,
             }}
             validationSchema={roomValidationSchema}
             onSubmit={async (values) => {
@@ -242,6 +244,11 @@ export default function RoomCreateForm() {
                 </div> */}
                     <GenerationModeSelectField />
                     <DifficultySelectField />
+                    <FormikSwitch
+                        id="hide-card"
+                        name="hideCard"
+                        label="Hide card initially?"
+                    />
                     <Accordion>
                         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                             Advanced Generation Options

--- a/web/src/components/board/Board.tsx
+++ b/web/src/components/board/Board.tsx
@@ -4,7 +4,32 @@ import Cell from './Cell';
 import { Box } from '@mui/material';
 
 export default function Board() {
-    const { board } = useContext(RoomContext);
+    const { board, revealCard } = useContext(RoomContext);
+
+    if (board.hidden) {
+        return (
+            <Box
+                sx={{
+                    aspectRatio: '1 / 1',
+                    maxHeight: '100%',
+                    maxWidth: '100%',
+                    border: 1,
+                    borderColor: 'divider',
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    cursor: 'pointer',
+                    ':hover': {
+                        background: (theme) => theme.palette.action.hover,
+                    },
+                }}
+                onClick={revealCard}
+            >
+                Click to reveal card
+            </Box>
+        );
+    }
+
     return (
         <Box
             sx={{

--- a/web/src/context/RoomContext.tsx
+++ b/web/src/context/RoomContext.tsx
@@ -67,6 +67,7 @@ interface RoomContext {
     racetimeReady: () => void;
     racetimeUnready: () => void;
     toggleGoalStar: (row: number, col: number) => void;
+    revealCard: () => void;
 }
 
 export const RoomContext = createContext<RoomContext>({
@@ -92,6 +93,7 @@ export const RoomContext = createContext<RoomContext>({
     racetimeReady() {},
     racetimeUnready() {},
     toggleGoalStar() {},
+    revealCard() {},
 });
 
 interface RoomContextProps {
@@ -406,6 +408,9 @@ export function RoomContextProvider({ slug, children }: RoomContextProps) {
         },
         [starredGoals, push, filter],
     );
+    const revealCard = useCallback(() => {
+        sendJsonMessage({ action: 'revealCard', authToken });
+    }, [sendJsonMessage, authToken]);
 
     // effects
     // slug changed, try to establish initial connection from storage
@@ -473,6 +478,7 @@ export function RoomContextProvider({ slug, children }: RoomContextProps) {
                 racetimeReady,
                 racetimeUnready,
                 toggleGoalStar,
+                revealCard,
             }}
         >
             {children}

--- a/web/src/types/Board.d.ts
+++ b/web/src/types/Board.d.ts
@@ -5,11 +5,11 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-/**
- * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
- */
-export interface Board {
+export type Board = RevealedBoard | HiddenBoard;
+
+export interface RevealedBoard {
   board: Cell[][];
+  hidden?: false;
 }
 /**
  * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
@@ -18,4 +18,7 @@ export interface Cell {
   goal: string;
   description: string;
   colors: string[];
+}
+export interface HiddenBoard {
+  hidden: true;
 }

--- a/web/src/types/RoomAction.d.ts
+++ b/web/src/types/RoomAction.d.ts
@@ -16,6 +16,7 @@ export type RoomAction = (
   | UnmarkAction
   | ChangeColorAction
   | NewCardAction
+  | RevealCardAction
 ) & {
   /**
    * JWT for the room obtained from the server
@@ -65,4 +66,7 @@ export interface NewCardAction {
     mode: string;
     difficulty?: string;
   };
+}
+export interface RevealCardAction {
+  action: "revealCard";
 }

--- a/web/src/types/ServerMessage.d.ts
+++ b/web/src/types/ServerMessage.d.ts
@@ -56,6 +56,7 @@ export type ChatMessage = (
       color: string;
     }
 )[];
+export type Board = RevealedBoard | HiddenBoard;
 
 /**
  * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
@@ -65,11 +66,12 @@ export interface Cell {
   description: string;
   colors: string[];
 }
-/**
- * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
- */
-export interface Board {
+export interface RevealedBoard {
   board: Cell[][];
+  hidden?: false;
+}
+export interface HiddenBoard {
+  hidden: true;
 }
 /**
  * Basic information about a room


### PR DESCRIPTION
Adds the ability for rooms to initially hide the card after generation. Each player must individually reveal the card in order to see it. The revealed status does not persist on the server, so if a player refreshes, they will need to re-reveal the card. Changing this would require more significant infrastructure changes that would be better scoped into development already proposing infrastructure changes, mostly because associating a specific socket with a token/payload would be a breaking change.

Rooms that have hidden cards will automatically hide new cards if a new card is generated within the room