### PR TITLE
Allow Random Generation to Respect Goal Categories

### DIFF
--- a/api/prisma/migrations/20241205231231_add_typed_random_flag/migration.sql
+++ b/api/prisma/migrations/20241205231231_add_typed_random_flag/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Game" ADD COLUMN     "useTypedRandom" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -65,6 +65,7 @@ model Game {
   difficultyVariants        DifficultyVariant[]
   difficultyGroups          Int?
   slugWords                 String[]            @default([])
+  useTypedRandom            Boolean             @default(false)
 }
 
 model DifficultyVariant {

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -11,6 +11,10 @@ import {
     addUnmarkAction,
     setRoomBoard,
 } from '../database/Rooms';
+import {
+    getDifficultyGroupCount,
+    getDifficultyVariant,
+} from '../database/games/Games';
 import { goalsForGame } from '../database/games/Goals';
 import {
     ChangeColorAction,
@@ -29,12 +33,9 @@ import {
 } from '../types/ServerMessage';
 import { shuffle } from '../util/Array';
 import { listToBoard } from '../util/RoomUtils';
+import { generateFullRandom } from './generation/Random';
 import { generateSRLv5 } from './generation/SRLv5';
 import RacetimeHandler, { RaceData } from './integration/RacetimeHandler';
-import {
-    getDifficultyGroupCount,
-    getDifficultyVariant,
-} from '../database/games/Games';
 
 type RoomIdentity = {
     nickname: string;
@@ -202,8 +203,7 @@ export default class Room {
                     break;
                 case BoardGenerationMode.RANDOM:
                 default:
-                    shuffle(goals, seed);
-                    goalList = goals.splice(0, 25);
+                    goalList = generateFullRandom(goals, seed);
                     break;
             }
         } catch (e) {

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -14,6 +14,7 @@ import {
 import {
     getDifficultyGroupCount,
     getDifficultyVariant,
+    useTypedRandom,
 } from '../database/games/Games';
 import { goalsForGame } from '../database/games/Goals';
 import {
@@ -33,7 +34,7 @@ import {
 } from '../types/ServerMessage';
 import { shuffle } from '../util/Array';
 import { listToBoard } from '../util/RoomUtils';
-import { generateFullRandom } from './generation/Random';
+import { generateFullRandom, generateRandomTyped } from './generation/Random';
 import { generateSRLv5 } from './generation/SRLv5';
 import RacetimeHandler, { RaceData } from './integration/RacetimeHandler';
 
@@ -202,6 +203,13 @@ export default class Room {
                     shuffle(goalList, seed);
                     break;
                 case BoardGenerationMode.RANDOM:
+                    if (await useTypedRandom(this.game)) {
+                        goalList = generateRandomTyped(goals, seed);
+                        goalList.shift();
+                    } else {
+                        goalList = generateFullRandom(goals, seed);
+                    }
+                    break;
                 default:
                     goalList = generateFullRandom(goals, seed);
                     break;

--- a/api/src/core/generation/Random.ts
+++ b/api/src/core/generation/Random.ts
@@ -1,0 +1,86 @@
+import { Goal } from '@prisma/client';
+import { shuffle } from '../../util/Array';
+
+const lineCheckList: number[][] = [];
+lineCheckList[1] = [1, 2, 3, 4, 5, 10, 15, 20, 6, 12, 18, 24];
+lineCheckList[2] = [0, 2, 3, 4, 6, 11, 16, 21];
+lineCheckList[3] = [0, 1, 3, 4, 7, 12, 17, 22];
+lineCheckList[4] = [0, 1, 2, 4, 8, 13, 18, 23];
+lineCheckList[5] = [0, 1, 2, 3, 8, 12, 16, 20, 9, 14, 19, 24];
+lineCheckList[6] = [0, 10, 15, 20, 6, 7, 8, 9];
+lineCheckList[7] = [0, 12, 18, 24, 5, 7, 8, 9, 1, 11, 16, 21];
+lineCheckList[8] = [5, 6, 8, 9, 2, 12, 17, 22];
+lineCheckList[9] = [4, 12, 16, 20, 9, 7, 6, 5, 3, 13, 18, 23];
+lineCheckList[10] = [4, 14, 19, 24, 8, 7, 6, 5];
+lineCheckList[11] = [0, 5, 15, 20, 11, 12, 13, 14];
+lineCheckList[12] = [1, 6, 16, 21, 10, 12, 13, 14];
+lineCheckList[13] = [
+    0, 6, 12, 18, 24, 20, 16, 8, 4, 2, 7, 17, 22, 10, 11, 13, 14,
+];
+lineCheckList[14] = [3, 8, 18, 23, 10, 11, 12, 14];
+lineCheckList[15] = [4, 9, 19, 24, 10, 11, 12, 13];
+lineCheckList[16] = [0, 5, 10, 20, 16, 17, 18, 19];
+lineCheckList[17] = [15, 17, 18, 19, 1, 6, 11, 21, 20, 12, 8, 4];
+lineCheckList[18] = [15, 16, 18, 19, 2, 7, 12, 22];
+lineCheckList[19] = [15, 16, 17, 19, 23, 13, 8, 3, 24, 12, 6, 0];
+lineCheckList[20] = [4, 9, 14, 24, 15, 16, 17, 18];
+lineCheckList[21] = [0, 5, 10, 15, 16, 12, 8, 4, 21, 22, 23, 24];
+lineCheckList[22] = [20, 22, 23, 24, 1, 6, 11, 16];
+lineCheckList[23] = [2, 7, 12, 17, 20, 21, 23, 24];
+lineCheckList[24] = [20, 21, 22, 24, 3, 8, 13, 18];
+lineCheckList[25] = [0, 6, 12, 18, 20, 21, 22, 23, 19, 14, 9, 4];
+
+export const generateRandomTyped = (goalList: Goal[], seed?: number) => {
+    const bingoBoard: Goal[] = [];
+
+    let goals = goalList;
+    shuffle(goals, seed);
+
+    function checkLine(i: number, typesA: string[]) {
+        let synergy = 0;
+        for (let j = 0; j < lineCheckList[i].length; j++) {
+            const typesB = bingoBoard[lineCheckList[i][j] + 1]?.categories;
+            if (typeof typesA != 'undefined' && typeof typesB != 'undefined') {
+                for (let k = 0; k < typesA.length; k++) {
+                    for (let l = 0; l < typesB.length; l++) {
+                        if (typesA[k] == typesB[l]) {
+                            synergy++;
+                            if (k == 0) {
+                                synergy++;
+                            }
+                            if (l == 0) {
+                                synergy++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return synergy;
+    }
+    for (let i = 1; i <= 25; i++) {
+        let j = 0,
+            synergy = 0,
+            currentObj: Goal,
+            minSynObj: { synergy: number; value: Goal } | null = null;
+        do {
+            currentObj = goals[j];
+            synergy = checkLine(i, currentObj.categories);
+            if (minSynObj == null || synergy < minSynObj.synergy) {
+                minSynObj = {
+                    synergy: synergy,
+                    value: currentObj,
+                };
+            }
+            j++;
+        } while (synergy != 0 && j < goals.length);
+        bingoBoard[i] = minSynObj?.value;
+        goals = goals.filter((g) => g.id !== minSynObj?.value.id);
+    }
+    return bingoBoard;
+};
+
+export const generateFullRandom = (goalList: Goal[], seed?: number) => {
+    shuffle(goalList, seed);
+    return goalList.splice(0, 25);
+};

--- a/api/src/database/games/Games.ts
+++ b/api/src/database/games/Games.ts
@@ -150,6 +150,10 @@ export const updateDifficultyGroups = (
     });
 };
 
+export const updateUseTypedRandom = (slug: string, useTypedRandom: boolean) => {
+    return prisma.game.update({ where: { slug }, data: { useTypedRandom } });
+};
+
 export const updateRacetimeCategory = (
     slug: string,
     racetimeCategory: string,
@@ -287,4 +291,11 @@ export const getDifficultyVariant = (id: string) => {
 export const getDifficultyGroupCount = async (slug: string) => {
     return (await prisma.game.findUnique({ where: { slug } }))
         ?.difficultyGroups;
+};
+
+export const useTypedRandom = async (slug: string) => {
+    return (
+        (await prisma.game.findUnique({ where: { slug } }))?.useTypedRandom ??
+        false
+    );
 };

--- a/api/src/routes/games/Games.ts
+++ b/api/src/routes/games/Games.ts
@@ -23,6 +23,7 @@ import {
     updateRacetimeGoal,
     updateSlugWords,
     updateSRLv5Enabled,
+    updateUseTypedRandom,
 } from '../../database/games/Games';
 import {
     createGoal,
@@ -86,6 +87,7 @@ games.post('/:slug', async (req, res) => {
         difficultyVariantsEnabled,
         difficultyGroups,
         slugWords,
+        useTypedRandom,
     } = req.body;
 
     let result = undefined;
@@ -124,6 +126,9 @@ games.post('/:slug', async (req, res) => {
             return res.status(400).send('Slug words can only contain letters');
         }
         result = await updateSlugWords(slug, slugWords);
+    }
+    if (useTypedRandom !== undefined) {
+        result = await updateUseTypedRandom(slug, !!useTypedRandom);
     }
 
     if (!result) {

--- a/api/src/types/Game.d.ts
+++ b/api/src/types/Game.d.ts
@@ -24,6 +24,7 @@ export interface Game {
   difficultyVariants?: DifficultyVariant[];
   difficultyGroups?: number;
   slugWords?: string[];
+  useTypedRandom?: boolean;
 }
 export interface User {
   id: string;

--- a/schema/schemas/Game.json
+++ b/schema/schemas/Game.json
@@ -19,7 +19,8 @@
         "difficultyVariantsEnabled": {"type": "boolean"},
         "difficultyVariants": {"type": "array", "items": {"$ref": "#/$defs/DifficultyVariant" }},
         "difficultyGroups": {"type": "number"},
-        "slugWords": {"type": "array", "items": {"type": "string"}}
+        "slugWords": {"type": "array", "items": {"type": "string"}},
+        "useTypedRandom": {"type": "boolean"}
     },
     "$defs": {
         "DifficultyVariant": {

--- a/schema/types/Game.d.ts
+++ b/schema/types/Game.d.ts
@@ -24,6 +24,7 @@ export interface Game {
   difficultyVariants?: DifficultyVariant[];
   difficultyGroups?: number;
   slugWords?: string[];
+  useTypedRandom?: boolean;
 }
 export interface User {
   id: string;

--- a/web/src/components/game/GameSettings.tsx
+++ b/web/src/components/game/GameSettings.tsx
@@ -164,6 +164,7 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                         gameData.difficultyVariantsEnabled,
                     difficultyGroups: gameData.difficultyGroups ?? 0,
                     slugWords: gameData.slugWords?.join('\n') ?? '',
+                    useTypedRandom: gameData.useTypedRandom,
                 }}
                 onSubmit={async ({
                     name,
@@ -174,6 +175,7 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                     difficultyVariantsEnabled,
                     difficultyGroups,
                     slugWords,
+                    useTypedRandom,
                 }) => {
                     const res = await fetch(`/api/games/${gameData.slug}`, {
                         method: 'POST',
@@ -189,6 +191,7 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                             difficultyVariantsEnabled,
                             difficultyGroups,
                             slugWords: slugWords.split('\n'),
+                            useTypedRandom,
                         }),
                     });
                     if (!res.ok) {
@@ -288,6 +291,22 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                                     </Typography>
                                 </HoverIcon>
                             </Box>
+                        </Box>
+                        <Box display="flex" alignItems="center">
+                            <FormikSwitch
+                                id="game-typed-random-switch"
+                                label="Enable Category-Random Generation"
+                                name="useTypedRandom"
+                            />
+                            <HoverIcon icon={<Info />}>
+                                <Typography variant="caption">
+                                    Category-Random generation allows random
+                                    generation to apply the typed restrictions
+                                    of SRLv5 generation, which attempts to
+                                    minimize the category overlap of each line.
+                                    Category-Random replaces Random generation.
+                                </Typography>
+                            </HoverIcon>
                         </Box>
                         {gameData.racetimeBeta && <RacetimeSettings />}
                         <Box>

--- a/web/src/components/game/Variants.tsx
+++ b/web/src/components/game/Variants.tsx
@@ -175,8 +175,6 @@ export default function Variants({ gameData }: VariantsProps) {
         return null;
     }
 
-    console.log('render');
-
     return (
         <>
             <Typography variant="h6">Difficulty Variants</Typography>

--- a/web/src/components/game/goals/GoalEditor.tsx
+++ b/web/src/components/game/goals/GoalEditor.tsx
@@ -90,7 +90,6 @@ export default function GoalEditor({
     categories,
     canModerate,
 }: GoalEditorProps) {
-    console.log(goal);
     return (
         <Formik
             initialValues={{

--- a/web/src/components/room/RoomControlDialog.tsx
+++ b/web/src/components/room/RoomControlDialog.tsx
@@ -69,7 +69,6 @@ export default function RoomControlDialog({
                         generationMode: '',
                     }}
                     onSubmit={({ seed, generationMode }) => {
-                        console.log(generationMode);
                         regenerateCard({
                             seed,
                             generationMode,

--- a/web/src/types/Game.d.ts
+++ b/web/src/types/Game.d.ts
@@ -24,6 +24,7 @@ export interface Game {
   difficultyVariants?: DifficultyVariant[];
   difficultyGroups?: number;
   slugWords?: string[];
+  useTypedRandom?: boolean;
 }
 export interface User {
   id: string;


### PR DESCRIPTION
Adds a game flag to toggle between pure random and Category-Random, the latter of which respects goal categories to minimize category overlap within lines, similar to SRLv5