### PR TITLE
Room Permission Infrastructure and Spectator Mode

### DIFF
--- a/api/src/auth/RoomAuth.ts
+++ b/api/src/auth/RoomAuth.ts
@@ -69,7 +69,8 @@ export const hasPermission = (
         case 'unmark':
             return !payload.isSpectating;
         case 'newCard':
-            return payload.isMonitor;
+            return true;
+        // return payload.isMonitor;
         case 'changeColor':
             return !payload.isSpectating;
         default:

--- a/api/src/auth/RoomAuth.ts
+++ b/api/src/auth/RoomAuth.ts
@@ -4,24 +4,21 @@ import { roomTokenSecret } from '../Environment';
 import { randomUUID } from 'crypto';
 import { RoomAction } from '../types/RoomAction';
 
-export type RoomTokenPayload = {
-    roomSlug: string;
-    uuid: string;
+type Permissions = {
     isSpectating: boolean;
     isMonitor: boolean;
 };
 
-type Permissions = Partial<{
-    [P in keyof RoomTokenPayload as RoomTokenPayload[P] extends boolean
-        ? P
-        : never]: RoomTokenPayload[P];
-}>;
+export type RoomTokenPayload = {
+    roomSlug: string;
+    uuid: string;
+} & Permissions;
 
 const tokenStore: string[] = [];
 
 export const createRoomToken = (
     room: Room,
-    { isSpectating, isMonitor }: Permissions,
+    { isSpectating, isMonitor }: Partial<Permissions>,
 ) => {
     const payload: RoomTokenPayload = {
         roomSlug: room.slug,

--- a/api/src/auth/RoomAuth.ts
+++ b/api/src/auth/RoomAuth.ts
@@ -8,19 +8,26 @@ export type RoomTokenPayload = {
     roomSlug: string;
     uuid: string;
     isSpectating: boolean;
+    isMonitor: boolean;
 };
 
-type Permissions = {
-    isSpectating?: boolean;
-};
+type Permissions = Partial<{
+    [P in keyof RoomTokenPayload as RoomTokenPayload[P] extends boolean
+        ? P
+        : never]: RoomTokenPayload[P];
+}>;
 
 const tokenStore: string[] = [];
 
-export const createRoomToken = (room: Room, { isSpectating }: Permissions) => {
+export const createRoomToken = (
+    room: Room,
+    { isSpectating, isMonitor }: Permissions,
+) => {
     const payload: RoomTokenPayload = {
         roomSlug: room.slug,
         uuid: randomUUID(),
         isSpectating: !!isSpectating,
+        isMonitor: !!isMonitor,
     };
     const token = sign(payload, roomTokenSecret);
     tokenStore.push(token);
@@ -62,7 +69,7 @@ export const hasPermission = (
         case 'unmark':
             return !payload.isSpectating;
         case 'newCard':
-            return !payload.isSpectating;
+            return payload.isMonitor;
         case 'changeColor':
             return !payload.isSpectating;
         default:

--- a/api/src/auth/RoomAuth.ts
+++ b/api/src/auth/RoomAuth.ts
@@ -2,18 +2,25 @@ import { sign, verify } from 'jsonwebtoken';
 import Room from '../core/Room';
 import { roomTokenSecret } from '../Environment';
 import { randomUUID } from 'crypto';
+import { RoomAction } from '../types/RoomAction';
 
 export type RoomTokenPayload = {
     roomSlug: string;
     uuid: string;
+    isSpectating: boolean;
+};
+
+type Permissions = {
+    isSpectating?: boolean;
 };
 
 const tokenStore: string[] = [];
 
-export const createRoomToken = (room: Room) => {
+export const createRoomToken = (room: Room, { isSpectating }: Permissions) => {
     const payload: RoomTokenPayload = {
         roomSlug: room.slug,
         uuid: randomUUID(),
+        isSpectating: !!isSpectating,
     };
     const token = sign(payload, roomTokenSecret);
     tokenStore.push(token);
@@ -40,5 +47,25 @@ export const verifyRoomToken = (
         return payload;
     } catch (e) {
         return false;
+    }
+};
+
+type RoomActions = RoomAction['action'];
+
+export const hasPermission = (
+    action: RoomActions,
+    payload: RoomTokenPayload,
+) => {
+    switch (action) {
+        case 'mark':
+            return !payload.isSpectating;
+        case 'unmark':
+            return !payload.isSpectating;
+        case 'newCard':
+            return !payload.isSpectating;
+        case 'changeColor':
+            return !payload.isSpectating;
+        default:
+            return true;
     }
 };

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -279,10 +279,14 @@ export default class Room {
                 return { action: 'unauthorized' };
             }
         }
-        this.sendChat([
-            { contents: identity.nickname, color: identity.color },
-            ' has joined.',
-        ]);
+        if (auth.isSpectating) {
+            this.sendChat(`${identity.nickname} is now spectating`);
+        } else {
+            this.sendChat([
+                { contents: identity.nickname, color: identity.color },
+                ' has joined.',
+            ]);
+        }
 
         this.connections.set(auth.uuid, socket);
         addJoinAction(this.id, identity.nickname, identity.color).then();

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -274,7 +274,7 @@ export default class Room {
         if (action.payload) {
             identity = {
                 nickname: action.payload.nickname,
-                color: 'blue',
+                color: auth.isSpectating ? '' : 'blue',
                 spectator: auth.isSpectating,
                 monitor: auth.isMonitor,
             };
@@ -524,7 +524,7 @@ export default class Room {
                 contents: identity.nickname,
                 color: identity.color,
             },
-            'has revealed the card.',
+            ' has revealed the card.',
         ]);
         return this.board;
     }

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -42,6 +42,8 @@ type RoomIdentity = {
     nickname: string;
     color: string;
     racetimeId?: string;
+    spectator: boolean;
+    monitor: boolean;
 };
 
 export enum BoardGenerationMode {
@@ -255,6 +257,8 @@ export default class Room {
                           finishTime: rtUser.finish_time ?? undefined,
                       }
                     : { connected: false },
+                spectator: i.spectator,
+                monitor: i.monitor,
             });
         });
         return players;
@@ -271,6 +275,8 @@ export default class Room {
             identity = {
                 nickname: action.payload.nickname,
                 color: 'blue',
+                spectator: auth.isSpectating,
+                monitor: auth.isMonitor,
             };
             this.identities.set(auth.uuid, identity);
         } else {

--- a/api/src/core/RoomServer.ts
+++ b/api/src/core/RoomServer.ts
@@ -1,5 +1,5 @@
 import { WebSocketServer } from 'ws';
-import { verifyRoomToken } from '../auth/RoomAuth';
+import { hasPermission, verifyRoomToken } from '../auth/RoomAuth';
 import { RoomAction } from '../types/RoomAction';
 import Room from './Room';
 
@@ -61,6 +61,11 @@ roomWebSocketServer.on('connection', (ws, req) => {
         if (action.action === 'join') {
             clearTimeout(timeout);
             ws.send(JSON.stringify(room.handleJoin(action, payload, ws)));
+        }
+
+        // helpers
+        if (!hasPermission(action.action, payload)) {
+            return ws.send(JSON.stringify({ action: 'forbidden' }));
         }
 
         switch (action.action) {

--- a/api/src/routes/rooms/Rooms.ts
+++ b/api/src/routes/rooms/Rooms.ts
@@ -131,7 +131,10 @@ rooms.post('/', async (req, res) => {
     await room.generateBoard(options);
     allRooms.set(slug, room);
 
-    const token = createRoomToken(room, { isSpectating: spectator });
+    const token = createRoomToken(room, {
+        isSpectating: spectator,
+        isMonitor: true,
+    });
 
     res.status(200).json({ slug, authToken: token });
 });

--- a/api/src/routes/rooms/Rooms.ts
+++ b/api/src/routes/rooms/Rooms.ts
@@ -50,6 +50,7 @@ rooms.post('/', async (req, res) => {
         difficulty,
         hideCard,
         seed,
+        spectator,
     } = req.body;
 
     if (!name || !game || !nickname /*|| !variant || !mode*/) {
@@ -130,7 +131,7 @@ rooms.post('/', async (req, res) => {
     await room.generateBoard(options);
     allRooms.set(slug, room);
 
-    const token = createRoomToken(room);
+    const token = createRoomToken(room, { isSpectating: spectator });
 
     res.status(200).json({ slug, authToken: token });
 });
@@ -223,7 +224,7 @@ rooms.get('/:slug', async (req, res) => {
 
 rooms.post('/:slug/authorize', (req, res) => {
     const { slug } = req.params;
-    const { password } = req.body;
+    const { password, spectator } = req.body;
     const room = allRooms.get(slug);
     if (!room) {
         res.sendStatus(404);
@@ -233,7 +234,8 @@ rooms.post('/:slug/authorize', (req, res) => {
         res.sendStatus(403);
         return;
     }
-    const token = createRoomToken(room);
+
+    const token = createRoomToken(room, { isSpectating: spectator });
     res.status(200).send({ authToken: token });
 });
 

--- a/api/src/types/Player.d.ts
+++ b/api/src/types/Player.d.ts
@@ -10,6 +10,8 @@ export interface Player {
   color: string;
   goalCount: number;
   racetimeStatus: RacetimeStatusDisconnected | RacetimeStatusConnected;
+  spectator: boolean;
+  monitor: boolean;
 }
 export interface RacetimeStatusDisconnected {
   connected: false;

--- a/api/src/types/ServerMessage.d.ts
+++ b/api/src/types/ServerMessage.d.ts
@@ -46,6 +46,9 @@ export type ServerMessage = (
       players: Player[];
       racetimeConnection: RacetimeConnection;
     }
+  | {
+      action: "forbidden";
+    }
 ) & {
   players?: Player[];
 };

--- a/api/src/types/ServerMessage.d.ts
+++ b/api/src/types/ServerMessage.d.ts
@@ -121,6 +121,8 @@ export interface Player {
   color: string;
   goalCount: number;
   racetimeStatus: RacetimeStatusDisconnected | RacetimeStatusConnected;
+  spectator: boolean;
+  monitor: boolean;
 }
 export interface RacetimeStatusDisconnected {
   connected: false;

--- a/schema/schemas/Player.json
+++ b/schema/schemas/Player.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,
-    "required": ["nickname", "color", "goalCount", "racetimeStatus"],
+    "required": ["nickname", "color", "goalCount", "racetimeStatus", "spectator", "monitor"],
     "properties": {
         "nickname": {"type": "string"},
         "color": {"type": "string"},
@@ -10,7 +10,9 @@
         "racetimeStatus": {"oneOf": [
             {"$ref": "#/$defs/RacetimeStatusDisconnected"},
             {"$ref": "#/$defs/RacetimeStatusConnected"}
-        ]}
+        ]},
+        "spectator": {"type": "boolean"},
+        "monitor": {"type": "boolean"}
     },
     "$defs": {
         "RacetimeStatusDisconnected": {

--- a/schema/schemas/ServerMessage.json
+++ b/schema/schemas/ServerMessage.json
@@ -76,6 +76,13 @@
                 "players":  {"type": "array", "items": {"$ref": "./Player.json"}},
                 "racetimeConnection": {"$ref": "./RoomData.json#/$defs/RacetimeConnection"}
             }
+        },
+        {
+            "required": ["action"],
+            "additionalProperties": false,
+            "properties": {
+                "action": "forbidden"
+            }
         }
     ]
 }

--- a/schema/types/Player.d.ts
+++ b/schema/types/Player.d.ts
@@ -10,6 +10,8 @@ export interface Player {
   color: string;
   goalCount: number;
   racetimeStatus: RacetimeStatusDisconnected | RacetimeStatusConnected;
+  spectator: boolean;
+  monitor: boolean;
 }
 export interface RacetimeStatusDisconnected {
   connected: false;

--- a/schema/types/ServerMessage.d.ts
+++ b/schema/types/ServerMessage.d.ts
@@ -46,6 +46,9 @@ export type ServerMessage = (
       players: Player[];
       racetimeConnection: RacetimeConnection;
     }
+  | {
+      action: "forbidden";
+    }
 ) & {
   players?: Player[];
 };

--- a/schema/types/ServerMessage.d.ts
+++ b/schema/types/ServerMessage.d.ts
@@ -121,6 +121,8 @@ export interface Player {
   color: string;
   goalCount: number;
   racetimeStatus: RacetimeStatusDisconnected | RacetimeStatusConnected;
+  spectator: boolean;
+  monitor: boolean;
 }
 export interface RacetimeStatusDisconnected {
   connected: false;

--- a/web/src/components/RoomCreateForm.tsx
+++ b/web/src/components/RoomCreateForm.tsx
@@ -249,6 +249,11 @@ export default function RoomCreateForm() {
                         name="hideCard"
                         label="Hide card initially?"
                     />
+                    <FormikSwitch
+                        name="spectator"
+                        id="spectator"
+                        label="Join as spectator?"
+                    />
                     <Accordion>
                         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                             Advanced Generation Options

--- a/web/src/components/room/PlayerList.tsx
+++ b/web/src/components/room/PlayerList.tsx
@@ -4,8 +4,15 @@ import { Box, Card, CardContent, CardHeader, Typography } from '@mui/material';
 import { Duration } from 'luxon';
 
 export default function PlayerList() {
-    const { players, roomData, joinRacetimeRoom } = useContext(RoomContext);
+    const {
+        players: allPlayers,
+        roomData,
+        joinRacetimeRoom,
+    } = useContext(RoomContext);
     const racetimeConnected = !!roomData?.racetimeConnection?.url;
+
+    const players = allPlayers.filter((p) => !p.spectator);
+    const spectators = allPlayers.filter((p) => p.spectator);
 
     return (
         <Card
@@ -58,6 +65,18 @@ export default function PlayerList() {
                                     )}
                                 </>
                             )}
+                        </Box>
+                    ))}
+                </Box>
+                <Typography variant="h6" pb={1}>
+                    Spectators
+                </Typography>
+                <Box display="flex" flexDirection="column" rowGap={3}>
+                    {spectators.map((player) => (
+                        <Box key={player.nickname}>
+                            <Box display="flex" columnGap={2}>
+                                <Typography>{player.nickname}</Typography>
+                            </Box>
                         </Box>
                     ))}
                 </Box>

--- a/web/src/components/room/RoomLogin.tsx
+++ b/web/src/components/room/RoomLogin.tsx
@@ -4,6 +4,7 @@ import { Form, Formik } from 'formik';
 import { useContext, useState } from 'react';
 import { RoomContext } from '../../context/RoomContext';
 import FormikTextField from '../input/FormikTextField';
+import FormikSwitch from '../input/FormikSwitch';
 
 export default function RoomLogin() {
     // context
@@ -25,9 +26,17 @@ export default function RoomLogin() {
                 }}
             >
                 <Formik
-                    initialValues={{ nickname: '', password: '' }}
-                    onSubmit={async ({ nickname, password }) => {
-                        const result = await connect(nickname, password);
+                    initialValues={{
+                        nickname: '',
+                        password: '',
+                        spectator: false,
+                    }}
+                    onSubmit={async ({ nickname, password, spectator }) => {
+                        const result = await connect(
+                            nickname,
+                            password,
+                            spectator,
+                        );
                         if (!result.success) {
                             setError(result.message);
                         }
@@ -50,6 +59,11 @@ export default function RoomLogin() {
                                 name="password"
                                 type="password"
                                 label="Password"
+                            />
+                            <FormikSwitch
+                                name="spectator"
+                                id="spectator"
+                                label="Join as spectator?"
                             />
                         </Box>
                         <Box display="flex">

--- a/web/src/context/RoomContext.tsx
+++ b/web/src/context/RoomContext.tsx
@@ -54,6 +54,7 @@ interface RoomContext {
     connect: (
         nickname: string,
         password: string,
+        spectator: boolean,
     ) => Promise<{ success: boolean; message?: string }>;
     sendChatMessage: (message: string) => void;
     markGoal: (row: number, col: number) => void;
@@ -265,11 +266,11 @@ export function RoomContextProvider({ slug, children }: RoomContextProps) {
         [sendJsonMessage],
     );
     const connect = useCallback(
-        async (nickname: string, password: string) => {
+        async (nickname: string, password: string, spectator: boolean) => {
             const res = await fetch(`/api/rooms/${slug}/authorize`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ password }),
+                body: JSON.stringify({ password, spectator }),
             });
             if (!res.ok) {
                 if (res.status === 403) {

--- a/web/src/types/Player.d.ts
+++ b/web/src/types/Player.d.ts
@@ -10,6 +10,8 @@ export interface Player {
   color: string;
   goalCount: number;
   racetimeStatus: RacetimeStatusDisconnected | RacetimeStatusConnected;
+  spectator: boolean;
+  monitor: boolean;
 }
 export interface RacetimeStatusDisconnected {
   connected: false;

--- a/web/src/types/ServerMessage.d.ts
+++ b/web/src/types/ServerMessage.d.ts
@@ -46,6 +46,9 @@ export type ServerMessage = (
       players: Player[];
       racetimeConnection: RacetimeConnection;
     }
+  | {
+      action: "forbidden";
+    }
 ) & {
   players?: Player[];
 };

--- a/web/src/types/ServerMessage.d.ts
+++ b/web/src/types/ServerMessage.d.ts
@@ -121,6 +121,8 @@ export interface Player {
   color: string;
   goalCount: number;
   racetimeStatus: RacetimeStatusDisconnected | RacetimeStatusConnected;
+  spectator: boolean;
+  monitor: boolean;
 }
 export interface RacetimeStatusDisconnected {
   connected: false;


### PR DESCRIPTION
Adds core infrastructure for room permissions and new spectator permission that prevents users from interacting with the room. This change also assigns the creator of the room with monitor permissions, which currently does nothing. In its current state, this change only works well with spectator mode, because permissions are lost when the room closes for any reason.

Future potential development in this vein
- Restrict actions such as regenerating the card to monitors
- Implicitly grant staff and category owners/moderators monitor permissions
- Allow monitors to promote new monitors
- Find a way to restore monitors when a room re-opens after being closed