### PR TITLE
Misellaneous Small Fixes

### DIFF
--- a/api/src/routes/goals/Goals.ts
+++ b/api/src/routes/goals/Goals.ts
@@ -33,7 +33,7 @@ goals.post('/:id', async (req, res) => {
     const { id } = req.params;
     const { goal, description, categories, difficulty } = req.body;
 
-    if (!goal && !description && !categories) {
+    if (!goal && description === undefined && !categories) {
         res.status(400).send('No changes submitted');
         return;
     }

--- a/api/src/routes/goals/Goals.ts
+++ b/api/src/routes/goals/Goals.ts
@@ -33,7 +33,7 @@ goals.post('/:id', async (req, res) => {
     const { id } = req.params;
     const { goal, description, categories, difficulty } = req.body;
 
-    if (!goal && description === undefined && !categories) {
+    if (!goal && description === undefined && !categories && !difficulty) {
         res.status(400).send('No changes submitted');
         return;
     }

--- a/api/src/routes/goals/Goals.ts
+++ b/api/src/routes/goals/Goals.ts
@@ -41,8 +41,13 @@ goals.post('/:id', async (req, res) => {
     const input: Prisma.GoalUpdateInput = {
         goal,
         description,
-        difficulty: difficulty && difficulty > 0 ? difficulty : null,
     };
+
+    if (difficulty === 0) {
+        input.difficulty = null;
+    } else if (difficulty > 0) {
+        input.difficulty = difficulty;
+    }
 
     if (categories) {
         input.categories = {

--- a/api/src/routes/goals/Goals.ts
+++ b/api/src/routes/goals/Goals.ts
@@ -33,7 +33,7 @@ goals.post('/:id', async (req, res) => {
     const { id } = req.params;
     const { goal, description, categories, difficulty } = req.body;
 
-    if (!goal && !description && !categories && !difficulty) {
+    if (!goal && !description && !categories) {
         res.status(400).send('No changes submitted');
         return;
     }
@@ -41,10 +41,8 @@ goals.post('/:id', async (req, res) => {
     const input: Prisma.GoalUpdateInput = {
         goal,
         description,
-        difficulty,
+        difficulty: difficulty && difficulty > 0 ? difficulty : null,
     };
-
-    console.log(categories);
 
     if (categories) {
         input.categories = {

--- a/api/src/tests/util/Array.test.ts
+++ b/api/src/tests/util/Array.test.ts
@@ -57,4 +57,14 @@ describe('shuffle', () => {
         shuffle(array);
         expect(array).not.toContain(undefined);
     });
+
+    it('should produce the same output when seeded', () => {
+        const array = [1, 2, 3, 4, 5];
+        const seed = 42;
+        const shuffled1 = [...array];
+        shuffle(shuffled1, seed);
+        const shuffled2 = [...array];
+        shuffle(shuffled2, seed);
+        expect(shuffled1).toEqual(shuffled2);
+    });
 });

--- a/api/src/tests/util/Array.test.ts
+++ b/api/src/tests/util/Array.test.ts
@@ -1,0 +1,60 @@
+import { shuffle } from '../../util/Array';
+
+describe('shuffle', () => {
+    it('should not change the array length', () => {
+        const original = [1, 2, 3, 4, 5];
+        const copy = [...original];
+        shuffle(copy);
+        expect(copy.length).toBe(original.length);
+    });
+
+    it('should contain the same elements after shuffle', () => {
+        const original = [1, 2, 3, 4, 5];
+        const copy = [...original];
+        shuffle(copy);
+        expect(copy.sort()).toEqual(original.sort());
+    });
+
+    it('should shuffle the array in place', () => {
+        const array = [1, 2, 3, 4, 5];
+        const ref = array;
+        shuffle(array);
+        expect(array).toBe(ref);
+    });
+
+    it('should not always return the same order', () => {
+        const input = [1, 2, 3, 4, 5];
+        const results = new Set<string>();
+
+        for (let i = 0; i < 20; i++) {
+            const copy = [...input];
+            shuffle(copy);
+            results.add(copy.join(','));
+        }
+
+        // Not a perfect test, but very unlikely to fail unless shuffle is broken
+        expect(results.size).toBeGreaterThan(1);
+    });
+
+    it('should handle empty array', () => {
+        const array: number[] = [];
+        shuffle(array);
+        expect(array).toEqual([]);
+    });
+
+    it('should handle single-element array', () => {
+        const array = [42];
+        shuffle(array);
+        expect(array).toEqual([42]);
+    });
+
+    // this tests a very specific bug that we ran into with a previous
+    // implementation. This is a known seed that caused the issue, but the
+    // difference in implementation means this seed may never be problematic
+    it('should not introduce undefined', () => {
+        const array = [1];
+        const seed = 609754;
+        shuffle(array);
+        expect(array).not.toContain(undefined);
+    });
+});

--- a/api/src/util/Array.ts
+++ b/api/src/util/Array.ts
@@ -27,15 +27,8 @@ export const shuffle = (array: unknown[], seedIn?: number) => {
     const seed = seedIn ?? Math.ceil(999999 * Math.random());
     const rng = prand.xoroshiro128plus(seed);
 
-    let m = array.length,
-        t,
-        i;
-
-    while (m) {
-        i = prand.unsafeUniformIntDistribution(0, m--, rng);
-
-        t = array[m];
-        array[m] = array[i];
-        array[i] = t;
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = prand.unsafeUniformIntDistribution(0, i, rng);
+        [array[i], array[j]] = [array[j], array[i]];
     }
 };

--- a/api/src/util/Array.ts
+++ b/api/src/util/Array.ts
@@ -24,7 +24,7 @@ export const chunk = <T>(array: T[], groupSize: number) => {
  * @param array the array to shuffle
  */
 export const shuffle = (array: unknown[], seedIn?: number) => {
-    const seed = seedIn ?? Math.ceil(999999 * Math.random());
+    const seed = seedIn ?? Date.now() ^ (Math.random() * 0x100000000);
     const rng = prand.xoroshiro128plus(seed);
 
     for (let i = array.length - 1; i > 0; i--) {

--- a/web/src/components/game/GameSettings.tsx
+++ b/web/src/components/game/GameSettings.tsx
@@ -266,7 +266,7 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                                 />
                                 <HoverIcon icon={<Info />}>
                                     <Typography variant="caption">
-                                        Difficulty varaints are a special type
+                                        Difficulty variants are a special type
                                         of variants that modify generation
                                         instead of the goal list. Difficulty
                                         variants modify how many goals from a

--- a/web/src/components/game/GameSettings.tsx
+++ b/web/src/components/game/GameSettings.tsx
@@ -169,6 +169,7 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                     useTypedRandom,
                 }) => {
                     let shouldDeleteCover = gameData.coverImage && !coverImage;
+                    console.log(coverImage !== gameData.coverImage);
                     const res = await fetch(`/api/games/${gameData.slug}`, {
                         method: 'POST',
                         headers: {
@@ -176,7 +177,10 @@ export default function GameSettings({ gameData }: GameSettingsProps) {
                         },
                         body: JSON.stringify({
                             name,
-                            coverImage,
+                            coverImage:
+                                coverImage !== gameData.coverImage
+                                    ? coverImage
+                                    : undefined,
                             enableSRLv5,
                             racetimeCategory,
                             racetimeGoal,

--- a/web/src/components/game/goals/GoalManagement.tsx
+++ b/web/src/components/game/goals/GoalManagement.tsx
@@ -33,14 +33,7 @@ export default function GoalManagement() {
     const dialogRef = useRef<DialogRef>(null);
 
     const openSettingsDialog = () => {
-        setDialogContent(
-            <SettingsDialogContent
-                showDetails={settings.showDetails}
-                setShowDetails={(value) =>
-                    setSettings({ ...settings, showDetails: value })
-                }
-            />,
-        );
+        setDialogContent(<SettingsDialogContent />);
         dialogRef.current?.open();
     };
 

--- a/web/src/components/input/SettingsDialogContent.tsx
+++ b/web/src/components/input/SettingsDialogContent.tsx
@@ -1,23 +1,37 @@
-import { DialogContent, DialogTitle, FormControlLabel, Switch } from '@mui/material';
+import {
+    DialogContent,
+    DialogTitle,
+    FormControlLabel,
+    Switch,
+} from '@mui/material';
+import { useGoalManagerContext } from '../../context/GoalManagerContext';
 
-interface SettingsDialogContentProps {
-    showDetails: boolean;
-    setShowDetails: (showDetails: boolean) => void;
-}
+interface SettingsDialogContentProps {}
 
-export const SettingsDialogContent: React.FC<SettingsDialogContentProps> = ({ showDetails, setShowDetails }) => (
-    <>
-        <DialogTitle>Goal Manager Settings</DialogTitle>
-        <DialogContent>
-            <FormControlLabel
-                control={
-                    <Switch
-                        checked={showDetails}
-                        onChange={(e) => setShowDetails(e.target.checked)}
-                    />
-                }
-                label="Display additional information in goal list"
-            />
-        </DialogContent>
-    </>
-);
+export const SettingsDialogContent: React.FC<
+    SettingsDialogContentProps
+> = ({}) => {
+    const { settings, setSettings } = useGoalManagerContext();
+
+    return (
+        <>
+            <DialogTitle>Goal Manager Settings</DialogTitle>
+            <DialogContent>
+                <FormControlLabel
+                    control={
+                        <Switch
+                            checked={settings.showDetails}
+                            onChange={(e) =>
+                                setSettings((curr) => ({
+                                    ...settings,
+                                    showDetails: e.target.checked,
+                                }))
+                            }
+                        />
+                    }
+                    label="Display additional information in goal list"
+                />
+            </DialogContent>
+        </>
+    );
+};

--- a/web/src/context/GoalManagerContext.tsx
+++ b/web/src/context/GoalManagerContext.tsx
@@ -45,7 +45,7 @@ interface GoalManagerContext {
     setSort: (sort: SortOptions) => void;
     setReverse: Dispatch<SetStateAction<boolean>>;
     setSearch: (search: string) => void;
-    setSettings: (settings: GoalManagerSettings) => void;
+    setSettings: Dispatch<SetStateAction<GoalManagerSettings>>;
     mutateGoals: KeyedMutator<Goal[]>;
     newGoal: boolean;
     setNewGoal: (newGoal: boolean) => void;
@@ -105,7 +105,9 @@ export function GoalManagerContextProvider({
     const [reverse, setReverse] = useState(false);
     const [search, setSearch] = useState('');
     //settings
-    const [settings, setSettings] = useState({ showDetails: true });
+    const [settings, setSettings] = useState<GoalManagerSettings>({
+        showDetails: true,
+    });
 
     // callbacks
     const deleteGoal = useCallback(

--- a/web/src/lib/Utils.ts
+++ b/web/src/lib/Utils.ts
@@ -5,7 +5,7 @@ import { Game } from '@playbingo/types';
 export function alertError(message: string) {
     toast.error(message, {
         position: 'top-right',
-        autoClose: 5000,
+        autoClose: 10000,
         hideProgressBar: false,
         closeOnClick: true,
         pauseOnHover: true,


### PR DESCRIPTION
# Changes
- A value of 0 for difficulty is now treated as null by the API, allowing difficulties to be removed from goals
- Auto generated seeds are now calculated using the current date instead of a static value

# Fixes
- Fixes a bug that prevented goal descriptions from being removed
- Fixes a bug that forced a goals difficulty to 0 on subsequent saves if it was initially unset
- Fixes a bug that could have potentially allowed a targeted request to delete difficulties from goals due to an unintended side effect
- Fixes a rendering bug in the goal manager settings dialog, so that it now updates properly alongside state
- Fixes a typo in help text
- Fixes a bug that caused the cover image to be sent in every game update request, preventing them from being applied on the server
- Fixes a bug in the Fisher-Yates shuffle algorithm to prevent `undefined` from being shuffled into the array and changing the length