### PR TITLE
Allow Login to be Done via Modal

### DIFF
--- a/web/src/app/(main)/@modal/(.)login/page.tsx
+++ b/web/src/app/(main)/@modal/(.)login/page.tsx
@@ -1,0 +1,10 @@
+import Login from '../../../../components/Login';
+import Modal from '../Modal';
+
+export default function LoginIntercept() {
+    return (
+        <Modal>
+            <Login useRouterBack />
+        </Modal>
+    );
+}

--- a/web/src/app/(main)/@modal/Modal.tsx
+++ b/web/src/app/(main)/@modal/Modal.tsx
@@ -1,0 +1,13 @@
+'use client';
+import { ReactNode } from 'react';
+import { Dialog, DialogContent } from '@mui/material';
+import { useRouter } from 'next/navigation';
+
+export default function Modal({ children }: { children: ReactNode }) {
+    const router = useRouter();
+    return (
+        <Dialog open onClose={() => router.back()}>
+            <DialogContent sx={{ p: 4 }}>{children}</DialogContent>
+        </Dialog>
+    );
+}

--- a/web/src/app/(main)/@modal/default.tsx
+++ b/web/src/app/(main)/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+    return null;
+}

--- a/web/src/app/(main)/layout.tsx
+++ b/web/src/app/(main)/layout.tsx
@@ -7,7 +7,13 @@ import 'react-toastify/dist/ReactToastify.css';
 import Footer from '../../components/footer/Footer';
 import Header from '../../components/header/Header';
 
-export default function CoreLayout({ children }: { children: ReactNode }) {
+export default function CoreLayout({
+    children,
+    modal,
+}: {
+    children: ReactNode;
+    modal: ReactNode;
+}) {
     return (
         <Box
             sx={{
@@ -32,13 +38,15 @@ export default function CoreLayout({ children }: { children: ReactNode }) {
             <Box
                 sx={{
                     flexGrow: 1,
-                    height: "100%",
-                    display: "flex"
-                }}>
+                    height: '100%',
+                    display: 'flex',
+                }}
+            >
                 {children}
             </Box>
             <Footer />
             <ToastContainer />
+            {modal}
         </Box>
     );
 }

--- a/web/src/app/(main)/login/page.tsx
+++ b/web/src/app/(main)/login/page.tsx
@@ -1,17 +1,15 @@
 'use client';
-import { Field, Form, Formik, FormikHelpers, FormikValues } from 'formik';
-import NextLink from 'next/link';
-import { useRouter } from 'next/navigation';
-import { useContext, useEffect, useState } from 'react';
-import { UserContext } from '../../../context/UserContext';
-import FormikTextField from '../../../components/input/FormikTextField';
-import { Box, Button, Link, Paper, Typography } from '@mui/material';
-import { login } from '../../../actions/Session';
 
-export default function Login() {
+import { Box, Paper } from '@mui/material';
+import { useRouter } from 'next/navigation';
+import { useContext, useEffect } from 'react';
+import Login from '../../../components/Login';
+import { UserContext } from '../../../context/UserContext';
+
+export default function LoginPage() {
     const router = useRouter();
-    const [error, setError] = useState('');
-    const { checkSession, user } = useContext(UserContext);
+
+    const { user } = useContext(UserContext);
 
     useEffect(() => {
         if (user) {
@@ -29,90 +27,7 @@ export default function Login() {
             }}
         >
             <Paper sx={{ px: 8, py: 4 }}>
-                <Box
-                    sx={{
-                        paddingBottom: 2,
-                        textAlign: 'center',
-                    }}
-                >
-                    <Typography variant="h4">Login to PlayBingo</Typography>
-                    <Typography
-                        variant="caption"
-                        sx={{
-                            color: 'text.secondary',
-                        }}
-                    >
-                        No login is required to play bingo.
-                    </Typography>
-                    {error && (
-                        <Typography variant="body2" color="error">
-                            {error}
-                        </Typography>
-                    )}
-                </Box>
-                <Formik
-                    initialValues={{ username: '', password: '' }}
-                    onSubmit={async ({ username, password }) => {
-                        const res = await login(username, password);
-                        if (!res.ok) {
-                            if (res.status === 401) {
-                                setError('Incorrect username or password.');
-                            } else {
-                                setError(
-                                    'An error occurred while processing your request.',
-                                );
-                            }
-                            return;
-                        }
-                        await checkSession();
-                        router.push('/');
-                    }}
-                >
-                    <Form>
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                flexDirection: 'column',
-                                rowGap: 2,
-                            }}
-                        >
-                            <FormikTextField
-                                id="username"
-                                name="username"
-                                label="Username"
-                            />
-                            <Box>
-                                <FormikTextField
-                                    id="password"
-                                    name="password"
-                                    label="Password"
-                                    type="password"
-                                    autoComplete="current-password"
-                                    fullWidth
-                                />
-                                <Link
-                                    href="/forgotpass"
-                                    component={NextLink}
-                                    variant="caption"
-                                >
-                                    Forgot password?
-                                </Link>
-                            </Box>
-                            <Box
-                                sx={{
-                                    textAlign: 'right',
-                                }}
-                            >
-                                <Button href="/register" component={NextLink}>
-                                    Register
-                                </Button>
-                                <Button type="submit" variant="contained">
-                                    Log In
-                                </Button>
-                            </Box>
-                        </Box>
-                    </Form>
-                </Formik>
+                <Login />
             </Paper>
         </Box>
     );

--- a/web/src/components/Login.tsx
+++ b/web/src/components/Login.tsx
@@ -1,0 +1,100 @@
+'use client';
+import { Box, Button, Link, Typography } from '@mui/material';
+import { Form, Formik } from 'formik';
+import NextLink from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { login } from '../actions/Session';
+import { useUserContext } from '../context/UserContext';
+import FormikTextField from './input/FormikTextField';
+
+interface LoginProps {
+    useRouterBack?: boolean;
+}
+
+export default function Login({ useRouterBack }: LoginProps) {
+    const { checkSession } = useUserContext();
+
+    const [error, setError] = useState('');
+
+    const router = useRouter();
+
+    return (
+        <>
+            <Box paddingBottom={2} textAlign="center">
+                <Typography variant="h4">Login to PlayBingo</Typography>
+                <Typography variant="caption" color="text.secondary">
+                    No login is required to play bingo.
+                </Typography>
+                {error && (
+                    <Typography variant="body2" color="error">
+                        {error}
+                    </Typography>
+                )}
+            </Box>
+            <Formik
+                initialValues={{ username: '', password: '' }}
+                onSubmit={async ({ username, password }) => {
+                    const res = await login(username, password);
+                    if (!res.ok) {
+                        if (res.status === 401) {
+                            setError('Incorrect username or password.');
+                        } else {
+                            setError(
+                                'An error occurred while processing your request.',
+                            );
+                        }
+                        return;
+                    }
+                    await checkSession();
+                    if (useRouterBack) {
+                        router.back();
+                    } else {
+                        router.push('/');
+                    }
+                }}
+            >
+                <Form>
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            rowGap: 2,
+                        }}
+                    >
+                        <FormikTextField
+                            id="username"
+                            name="username"
+                            label="Username"
+                        />
+                        <Box>
+                            <FormikTextField
+                                id="password"
+                                name="password"
+                                label="Password"
+                                type="password"
+                                autoComplete="current-password"
+                                fullWidth
+                            />
+                            <Link
+                                href="/forgotpass"
+                                component={NextLink}
+                                variant="caption"
+                            >
+                                Forgot password?
+                            </Link>
+                        </Box>
+                        <Box textAlign="right">
+                            <Button href="/register" component={NextLink}>
+                                Register
+                            </Button>
+                            <Button type="submit" variant="contained">
+                                Log In
+                            </Button>
+                        </Box>
+                    </Box>
+                </Form>
+            </Formik>
+        </>
+    );
+}


### PR DESCRIPTION
Sets up login as an intercepting route to allow it to render as a modal in the main web routes, rather than forcing a redirect to the login page and then a redirect to the homepage afterwards. This allows logins to be done without leaving the current page.

You may need to delete your local `.next` folder for this to work in development due to caching/build optimizations