### PR TITLE
Send Full Goal Data in Rooms

### DIFF
--- a/api/docs/websocket.md
+++ b/api/docs/websocket.md
@@ -76,8 +76,13 @@ information and the current room state.
   "board": {
     "board": [
       {
-        "goal": "Complete a goal",
-        "description": "Complete any goal by any means necessary",
+        "goal": {
+            "id": "abc23",
+            "goal": "Complete a goal",
+            "description": "Complete any goal by any means necessary",
+            "difficulty": 1,
+            "categories": ["cat1", "cat2"]
+        },
         "colors": ["blue", "#00ffaa"]
       }
     ]
@@ -144,13 +149,23 @@ contains the new board state.
     "board": [
       [
         {
-          "goal": "Goal 1",
-          "description": "Description of goal 1",
+          "goal": {
+            "id": "abc23",
+            "goal": "Goal 1",
+            "description": "Description of goal 1",
+            "difficulty": 1,
+            "categories": ["cat2"]
+        },
           "colors": ["red"]
         },
         {
-          "goal": "Goal 2",
-          "description": "Description of goal 2",
+          "goal": "goal": {
+            "id": "abc23",
+            "goal": "Goal 2",
+            "description": "Description of goal 2",
+            "difficulty": 1,
+            "categories": ["cat1",]
+        },
           "colors": ["blue"]
         }
       ]

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -301,9 +301,7 @@ export default class Room {
         this.sendSyncBoard();
         setRoomBoard(
             this.id,
-            this.board.board
-                .flat()
-                .map((cell) => `${cell.goal}::${cell.description}`),
+            this.board.board.flat().map((cell) => cell.goal.id),
         );
     }
 

--- a/api/src/core/generation/GeneratorCore.ts
+++ b/api/src/core/generation/GeneratorCore.ts
@@ -1,4 +1,5 @@
 export interface GeneratorGoal {
+    id: string;
     goal: string;
     description: string | null;
     categories: string[];

--- a/api/src/database/games/Goals.ts
+++ b/api/src/database/games/Goals.ts
@@ -165,3 +165,10 @@ export const deleteAllGoalsForGame = async (gameSlug: string) => {
         return false;
     }
 };
+
+export const getGoalList = (ids: string[]) => {
+    if (ids.length === 0) {
+        return [];
+    }
+    return prisma.goal.findMany({ where: { id: { in: ids } } });
+};

--- a/api/src/routes/rooms/Rooms.ts
+++ b/api/src/routes/rooms/Rooms.ts
@@ -17,6 +17,7 @@ import { gameForSlug, goalCount } from '../../database/games/Games';
 import { chunk } from '../../util/Array';
 import { randomWord, slugAdjectives, slugNouns } from '../../util/Words';
 import { handleAction } from './actions/Actions';
+import { getGoalList } from '../../database/games/Goals';
 
 const MIN_ROOM_GOALS_REQUIRED = 25;
 const rooms = Router();
@@ -189,9 +190,8 @@ rooms.get('/:slug', async (req, res) => {
     );
     room.board = {
         board: chunk(
-            dbRoom.board.map((goal) => ({
-                goal: goal.split('::')[0],
-                description: goal.split('::', 2)[1] ?? '',
+            (await getGoalList(dbRoom.board)).map((goal) => ({
+                goal: goal,
                 colors: [],
             })),
             5,

--- a/api/src/tests/core/boardGenerator.test.ts
+++ b/api/src/tests/core/boardGenerator.test.ts
@@ -19,6 +19,7 @@ const categories: Category[] = Array.from({ length: 7 }).map((_, i) => ({
 }));
 
 const goals: GeneratorGoal[] = Array.from({ length: 100 }).map((_, i) => ({
+    id: `${i}`,
     goal: `Goal ${i + 1}`,
     description: `Description for Goal ${i + 1}`,
     categories: [

--- a/api/src/tests/util/WinDetection.test.ts
+++ b/api/src/tests/util/WinDetection.test.ts
@@ -4,6 +4,7 @@ import { checkCompletedLines, listToBoard } from '../../util/RoomUtils';
 const createBoard = (): Cell[][] =>
     listToBoard(
         Array.from({ length: 25 }).map((_, i) => ({
+            id: `${i}`,
             goal: `Goal ${i + 1}`,
             categories: [],
             difficulty: 0,

--- a/api/src/util/RoomUtils.ts
+++ b/api/src/util/RoomUtils.ts
@@ -2,11 +2,10 @@ import { Cell } from '@playbingo/types';
 import { GeneratorGoal } from '../core/generation/GeneratorCore';
 import { chunk } from './Array';
 
-export const listToBoard = (list: GeneratorGoal[]) => {
+export const listToBoard = (list: GeneratorGoal[]): Cell[][] => {
     return chunk(
         list.map((g) => ({
-            goal: `${g.goal}`,
-            description: g.description ?? '',
+            goal: g,
             colors: [],
         })),
         5,

--- a/schema/schemas/Cell.json
+++ b/schema/schemas/Cell.json
@@ -5,8 +5,7 @@
     "required": ["goal", "description", "colors"],
     "description": "An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action",
     "properties": {
-        "goal": {"type": "string"},
-        "description": {"type": "string"},
+        "goal": {"$ref": "./Goal.json"},
         "colors": {"type": "array", "items": {"type": "string"}}
     }
 }

--- a/schema/schemas/Goal.json
+++ b/schema/schemas/Goal.json
@@ -7,8 +7,8 @@
     "properties": {
         "id": {"type": "string"},
         "goal": {"type": "string"},
-        "description": {"type": "string"},
-        "difficulty": {"type": "number"},
+        "description": {"type": ["string", "null"]},
+        "difficulty": {"type": ["number", "null"]},
         "categories": {"type": "array", "items": {"type": "string"}}
     }
 }

--- a/schema/types/Board.d.ts
+++ b/schema/types/Board.d.ts
@@ -15,9 +15,18 @@ export interface RevealedBoard {
  * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
  */
 export interface Cell {
-  goal: string;
-  description: string;
+  goal: Goal;
   colors: string[];
+}
+/**
+ * A single objective for a bingo game.
+ */
+export interface Goal {
+  id: string;
+  goal: string;
+  description: string | null;
+  difficulty?: number | null;
+  categories?: string[];
 }
 export interface HiddenBoard {
   hidden: true;

--- a/schema/types/Cell.d.ts
+++ b/schema/types/Cell.d.ts
@@ -9,7 +9,16 @@
  * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
  */
 export interface Cell {
-  goal: string;
-  description: string;
+  goal: Goal;
   colors: string[];
+}
+/**
+ * A single objective for a bingo game.
+ */
+export interface Goal {
+  id: string;
+  goal: string;
+  description: string | null;
+  difficulty?: number | null;
+  categories?: string[];
 }

--- a/schema/types/Goal.d.ts
+++ b/schema/types/Goal.d.ts
@@ -11,7 +11,7 @@
 export interface Goal {
   id: string;
   goal: string;
-  description: string;
-  difficulty?: number;
+  description: string | null;
+  difficulty?: number | null;
   categories?: string[];
 }

--- a/schema/types/ServerMessage.d.ts
+++ b/schema/types/ServerMessage.d.ts
@@ -65,9 +65,18 @@ export type Board = RevealedBoard | HiddenBoard;
  * An incoming websocket message from the server telling the client of a change in room state or instructing it to take an action
  */
 export interface Cell {
-  goal: string;
-  description: string;
+  goal: Goal;
   colors: string[];
+}
+/**
+ * A single objective for a bingo game.
+ */
+export interface Goal {
+  id: string;
+  goal: string;
+  description: string | null;
+  difficulty?: number | null;
+  categories?: string[];
 }
 export interface RevealedBoard {
   board: Cell[][];

--- a/web/src/components/board/Board.tsx
+++ b/web/src/components/board/Board.tsx
@@ -53,7 +53,7 @@ export default function Board() {
                 >
                     {row.map((goal, colIndex) => (
                         <Cell
-                            key={`(${rowIndex},${colIndex})`}
+                            key={goal.goal.id}
                             row={rowIndex}
                             col={colIndex}
                             cell={goal}

--- a/web/src/components/board/Cell.tsx
+++ b/web/src/components/board/Cell.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Box, Tooltip } from '@mui/material';
+import { Box, Tooltip, Typography } from '@mui/material';
 import { useCallback, useContext } from 'react';
 import { RoomContext } from '../../context/RoomContext';
 import { Cell } from '@playbingo/types';
@@ -18,8 +18,14 @@ export default function BoardCell({
     col,
 }: CellProps) {
     // context
-    const { color, markGoal, unmarkGoal, starredGoals, toggleGoalStar } =
-        useContext(RoomContext);
+    const {
+        color,
+        markGoal,
+        unmarkGoal,
+        starredGoals,
+        toggleGoalStar,
+        showGoalDetails,
+    } = useContext(RoomContext);
 
     // callbacks
     const toggleSpace = useCallback(() => {
@@ -36,7 +42,17 @@ export default function BoardCell({
 
     return (
         <Tooltip
-            title={goal.description}
+            title={
+                showGoalDetails ? (
+                    <>
+                        <Box sx={{ pb: 1.5 }}>{goal.description}</Box>
+                        <Box>Difficulty: {goal.difficulty}</Box>
+                        <Box>Categories: {goal.categories?.join(', ')}</Box>
+                    </>
+                ) : (
+                    goal.description
+                )
+            }
             arrow
             slotProps={{
                 popper: {

--- a/web/src/components/board/Cell.tsx
+++ b/web/src/components/board/Cell.tsx
@@ -13,7 +13,7 @@ interface CellProps {
 }
 
 export default function BoardCell({
-    cell: { goal, description, colors },
+    cell: { goal, colors },
     row,
     col,
 }: CellProps) {
@@ -34,11 +34,9 @@ export default function BoardCell({
     const colorPortion = 360 / colors.length;
     const isStarred = starredGoals.includes(row * 5 + col);
 
-    console.log(description);
-
     return (
         <Tooltip
-            title={description}
+            title={goal.description}
             arrow
             slotProps={{
                 popper: {
@@ -90,7 +88,7 @@ export default function BoardCell({
                     }}
                 >
                     <TextFit
-                        text={goal}
+                        text={goal.goal}
                         sx={{
                             p: 1,
                             filter: 'drop-shadow(2px 2px 2px rgba(0,0,0,0))',

--- a/web/src/components/room/RoomControlDialog.tsx
+++ b/web/src/components/room/RoomControlDialog.tsx
@@ -9,9 +9,11 @@ import {
     DialogContent,
     DialogTitle,
     FormControl,
+    FormControlLabel,
     InputLabel,
     MenuItem,
     Select,
+    Switch,
     Typography,
 } from '@mui/material';
 import { Field, Form, Formik } from 'formik';
@@ -31,7 +33,13 @@ export default function RoomControlDialog({
     show,
     close,
 }: RoomControlDialogProps) {
-    const { roomData, regenerateCard, board } = useContext(RoomContext);
+    const {
+        roomData,
+        regenerateCard,
+        board,
+        showGoalDetails,
+        toggleGoalDetails,
+    } = useContext(RoomContext);
 
     const modes = useAsync(async () => {
         if (!roomData) {
@@ -146,6 +154,16 @@ export default function RoomControlDialog({
                         pt: 2,
                     }}
                 >
+                    <Typography variant="h6">Local Actions</Typography>
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={showGoalDetails}
+                                onChange={toggleGoalDetails}
+                            />
+                        }
+                        label="Show All Goal Details"
+                    />
                     <Typography variant="h6">Local Actions</Typography>
                     <Typography variant="caption">
                         These actions are potentially destructive and should

--- a/web/src/context/RoomContext.tsx
+++ b/web/src/context/RoomContext.tsx
@@ -51,6 +51,7 @@ interface RoomContext {
     nickname: string;
     players: Player[];
     starredGoals: number[];
+    showGoalDetails: boolean;
     connect: (
         nickname: string,
         password: string,
@@ -69,6 +70,7 @@ interface RoomContext {
     racetimeUnready: () => void;
     toggleGoalStar: (row: number, col: number) => void;
     revealCard: () => void;
+    toggleGoalDetails: () => void;
 }
 
 export const RoomContext = createContext<RoomContext>({
@@ -79,6 +81,7 @@ export const RoomContext = createContext<RoomContext>({
     nickname: '',
     players: [],
     starredGoals: [],
+    showGoalDetails: false,
     async connect() {
         return { success: false };
     },
@@ -95,6 +98,7 @@ export const RoomContext = createContext<RoomContext>({
     racetimeUnready() {},
     toggleGoalStar() {},
     revealCard() {},
+    toggleGoalDetails() {},
 });
 
 interface RoomContextProps {
@@ -118,6 +122,8 @@ export function RoomContextProvider({ slug, children }: RoomContextProps) {
     const [notFound, setNotFound] = useState(false);
 
     const [starredGoals, { push, clear, filter }] = useList<number>([]);
+
+    const [showGoalDetails, setShoWGoalDetails] = useState(false);
 
     const latestConnectionStatus = useLatest(connectionStatusState);
     const connectionStatus = latestConnectionStatus.current;
@@ -427,6 +433,11 @@ export function RoomContextProvider({ slug, children }: RoomContextProps) {
     const revealCard = useCallback(() => {
         sendJsonMessage({ action: 'revealCard', authToken });
     }, [sendJsonMessage, authToken]);
+    const toggleGoalDetails = useCallback(() => {
+        setShoWGoalDetails((curr) => {
+            return !curr;
+        });
+    }, []);
 
     // effects
     // slug changed, try to establish initial connection from storage
@@ -514,6 +525,7 @@ export function RoomContextProvider({ slug, children }: RoomContextProps) {
                 nickname,
                 players,
                 starredGoals,
+                showGoalDetails,
                 connect,
                 sendChatMessage,
                 markGoal,
@@ -528,6 +540,7 @@ export function RoomContextProvider({ slug, children }: RoomContextProps) {
                 racetimeUnready,
                 toggleGoalStar,
                 revealCard,
+                toggleGoalDetails,
             }}
         >
             {children}


### PR DESCRIPTION
Updates the structure of room data sent over websocket to include the entire goal structure as used by the goal editor. Adding the goal id to the structure means clients can uniquely identify goals more easily or do lookups in their own local data for the goal. This change serves as a prerequisite for eventually adding metadata to goals to simplify special client consumption use cases, such as auto tracking. Having the id means the database can save an array of goal ids instead of an array of stringified goal data

Additionally, this adds a toggle to rooms to show goal details, which adds the difficulty and category list to the goal tooltip

**Breaking change** - this is a breaking change in type definitions and in the database. Existing clients must update to respect the new type definitions or they will no longer work, and the server will not be able to load boards for rooms created prior to this.