### PR TITLE
Add Goal Counters

### DIFF
--- a/web/src/components/board/Cell.tsx
+++ b/web/src/components/board/Cell.tsx
@@ -27,6 +27,7 @@ export default function BoardCell({
         starredGoals,
         toggleGoalStar,
         showGoalDetails,
+        showCounters,
     } = useContext(RoomContext);
 
     // callbacks
@@ -144,59 +145,61 @@ export default function BoardCell({
                         }}
                     />
                 ))}
-                <Box
-                    sx={{
-                        position: 'absolute',
-                        bottom: 0,
-                        display: 'flex',
-                        zIndex: 30,
-                        backgroundColor: 'rgba(0,0,0,0.7)',
-                        alignContent: 'center',
-                        px: 0.5,
-                        py: 0.2,
-                        fontSize: '1rem',
-                        '& > div': {
-                            cursor: 'pointer',
-                            px: 0.5,
-                            userSelect: 'none',
-                            ':hover': {
-                                color: 'yellow',
-                            },
-                        },
-                        width: '100%',
-                    }}
-                >
-                    <IconButton
-                        size="small"
-                        onClick={(e) => {
-                            updateProgress(-1);
-                            e.stopPropagation;
-                        }}
-                    >
-                        <Remove fontSize="small" />
-                    </IconButton>
-                    <Typography
+                {showCounters && (
+                    <Box
                         sx={{
-                            textAlign: 'center',
-                            zIndex: 20,
-                            color: 'white',
-                            textShadow: '1px 1px 10px rgba(0,0,0,0.9)',
-                            pointerEvents: 'none',
-                            flexGrow: 1,
+                            position: 'absolute',
+                            bottom: 0,
+                            display: 'flex',
+                            zIndex: 30,
+                            backgroundColor: 'rgba(0,0,0,0.7)',
+                            alignContent: 'center',
+                            px: 0.5,
+                            py: 0.2,
+                            fontSize: '1rem',
+                            '& > div': {
+                                cursor: 'pointer',
+                                px: 0.5,
+                                userSelect: 'none',
+                                ':hover': {
+                                    color: 'yellow',
+                                },
+                            },
+                            width: '100%',
                         }}
                     >
-                        {counter}
-                    </Typography>
-                    <IconButton
-                        size="small"
-                        onClick={(e) => {
-                            updateProgress(+1);
-                            e.stopPropagation();
-                        }}
-                    >
-                        <Add fontSize="small" />
-                    </IconButton>
-                </Box>
+                        <IconButton
+                            size="small"
+                            onClick={(e) => {
+                                updateProgress(-1);
+                                e.stopPropagation;
+                            }}
+                        >
+                            <Remove fontSize="small" />
+                        </IconButton>
+                        <Typography
+                            sx={{
+                                textAlign: 'center',
+                                zIndex: 20,
+                                color: 'white',
+                                textShadow: '1px 1px 10px rgba(0,0,0,0.9)',
+                                pointerEvents: 'none',
+                                flexGrow: 1,
+                            }}
+                        >
+                            {counter}
+                        </Typography>
+                        <IconButton
+                            size="small"
+                            onClick={(e) => {
+                                updateProgress(+1);
+                                e.stopPropagation();
+                            }}
+                        >
+                            <Add fontSize="small" />
+                        </IconButton>
+                    </Box>
+                )}
                 {isStarred && (
                     <Box sx={{ position: 'absolute', right: 0 }}>
                         <Star />

--- a/web/src/components/board/Cell.tsx
+++ b/web/src/components/board/Cell.tsx
@@ -1,10 +1,12 @@
 'use client';
-import { Box, Tooltip, Typography } from '@mui/material';
-import { useCallback, useContext } from 'react';
-import { RoomContext } from '../../context/RoomContext';
-import { Cell } from '@playbingo/types';
-import TextFit from '../TextFit';
+import Add from '@mui/icons-material/Add';
+import Remove from '@mui/icons-material/Remove';
 import Star from '@mui/icons-material/Star';
+import { Box, IconButton, Tooltip, Typography } from '@mui/material';
+import { Cell } from '@playbingo/types';
+import { useCallback, useContext, useMemo, useState } from 'react';
+import { RoomContext } from '../../context/RoomContext';
+import TextFit from '../TextFit';
 
 interface CellProps {
     cell: Cell;
@@ -39,6 +41,19 @@ export default function BoardCell({
     // calculations
     const colorPortion = 360 / colors.length;
     const isStarred = starredGoals.includes(row * 5 + col);
+
+    const cellId = useMemo(() => `${row},${col}`, [row, col]);
+    const [counter, setCounter] = useState(0);
+
+    const progressMax = goal.description?.match(/\b(\d+)\b$/)?.[1];
+    const maxValue = progressMax ? parseInt(progressMax) : undefined;
+
+    const updateProgress = useCallback((delta: number) => {
+        setCounter((prev) => {
+            const next = Math.max(0, prev + delta);
+            return next;
+        });
+    }, []);
 
     return (
         <Tooltip
@@ -90,6 +105,9 @@ export default function BoardCell({
                     toggleGoalStar(row, col);
                     e.preventDefault();
                 }}
+                onWheel={(e) => {
+                    updateProgress(e.deltaY < 0 ? +1 : -1);
+                }}
             >
                 <Box
                     sx={{
@@ -126,6 +144,59 @@ export default function BoardCell({
                         }}
                     />
                 ))}
+                <Box
+                    sx={{
+                        position: 'absolute',
+                        bottom: 0,
+                        display: 'flex',
+                        zIndex: 30,
+                        backgroundColor: 'rgba(0,0,0,0.7)',
+                        alignContent: 'center',
+                        px: 0.5,
+                        py: 0.2,
+                        fontSize: '1rem',
+                        '& > div': {
+                            cursor: 'pointer',
+                            px: 0.5,
+                            userSelect: 'none',
+                            ':hover': {
+                                color: 'yellow',
+                            },
+                        },
+                        width: '100%',
+                    }}
+                >
+                    <IconButton
+                        size="small"
+                        onClick={(e) => {
+                            updateProgress(-1);
+                            e.stopPropagation;
+                        }}
+                    >
+                        <Remove fontSize="small" />
+                    </IconButton>
+                    <Typography
+                        sx={{
+                            textAlign: 'center',
+                            zIndex: 20,
+                            color: 'white',
+                            textShadow: '1px 1px 10px rgba(0,0,0,0.9)',
+                            pointerEvents: 'none',
+                            flexGrow: 1,
+                        }}
+                    >
+                        {counter}
+                    </Typography>
+                    <IconButton
+                        size="small"
+                        onClick={(e) => {
+                            updateProgress(+1);
+                            e.stopPropagation();
+                        }}
+                    >
+                        <Add fontSize="small" />
+                    </IconButton>
+                </Box>
                 {isStarred && (
                     <Box sx={{ position: 'absolute', right: 0 }}>
                         <Star />

--- a/web/src/components/board/Cell.tsx
+++ b/web/src/components/board/Cell.tsx
@@ -43,12 +43,7 @@ export default function BoardCell({
     const colorPortion = 360 / colors.length;
     const isStarred = starredGoals.includes(row * 5 + col);
 
-    const cellId = useMemo(() => `${row},${col}`, [row, col]);
     const [counter, setCounter] = useState(0);
-
-    const progressMax = goal.description?.match(/\b(\d+)\b$/)?.[1];
-    const maxValue = progressMax ? parseInt(progressMax) : undefined;
-
     const updateProgress = useCallback((delta: number) => {
         setCounter((prev) => {
             const next = Math.max(0, prev + delta);

--- a/web/src/components/board/Cell.tsx
+++ b/web/src/components/board/Cell.tsx
@@ -150,6 +150,7 @@ export default function BoardCell({
                             px: 0.5,
                             py: 0.2,
                             width: '100%',
+                            zIndex: 30,
                         }}
                     >
                         <IconButton

--- a/web/src/components/board/Cell.tsx
+++ b/web/src/components/board/Cell.tsx
@@ -151,20 +151,9 @@ export default function BoardCell({
                             position: 'absolute',
                             bottom: 0,
                             display: 'flex',
-                            zIndex: 30,
                             backgroundColor: 'rgba(0,0,0,0.7)',
-                            alignContent: 'center',
                             px: 0.5,
                             py: 0.2,
-                            fontSize: '1rem',
-                            '& > div': {
-                                cursor: 'pointer',
-                                px: 0.5,
-                                userSelect: 'none',
-                                ':hover': {
-                                    color: 'yellow',
-                                },
-                            },
                             width: '100%',
                         }}
                     >
@@ -180,9 +169,7 @@ export default function BoardCell({
                         <Typography
                             sx={{
                                 textAlign: 'center',
-                                zIndex: 20,
                                 color: 'white',
-                                textShadow: '1px 1px 10px rgba(0,0,0,0.9)',
                                 pointerEvents: 'none',
                                 flexGrow: 1,
                             }}

--- a/web/src/components/room/RoomControlDialog.tsx
+++ b/web/src/components/room/RoomControlDialog.tsx
@@ -166,13 +166,6 @@ export default function RoomControlDialog({
                         }
                         label="Show Counters"
                     />
-                </Box>
-                <Box
-                    sx={{
-                        pt: 2,
-                    }}
-                >
-                    <Typography variant="h6">Local Actions</Typography>
                     <FormControlLabel
                         control={
                             <Switch

--- a/web/src/components/room/RoomControlDialog.tsx
+++ b/web/src/components/room/RoomControlDialog.tsx
@@ -164,7 +164,7 @@ export default function RoomControlDialog({
                                 onChange={toggleCounters}
                             />
                         }
-                        label="Show All Goal Details"
+                        label="Show Counters"
                     />
                 </Box>
                 <Box

--- a/web/src/components/room/RoomControlDialog.tsx
+++ b/web/src/components/room/RoomControlDialog.tsx
@@ -39,6 +39,8 @@ export default function RoomControlDialog({
         board,
         showGoalDetails,
         toggleGoalDetails,
+        showCounters,
+        toggleCounters,
     } = useContext(RoomContext);
 
     const modes = useAsync(async () => {
@@ -149,6 +151,22 @@ export default function RoomControlDialog({
                         </Form>
                     )}
                 </Formik>
+                <Box
+                    sx={{
+                        pt: 2,
+                    }}
+                >
+                    <Typography variant="h6">Settings</Typography>
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={showCounters}
+                                onChange={toggleCounters}
+                            />
+                        }
+                        label="Show All Goal Details"
+                    />
+                </Box>
                 <Box
                     sx={{
                         pt: 2,

--- a/web/src/context/RoomContext.tsx
+++ b/web/src/context/RoomContext.tsx
@@ -52,6 +52,7 @@ interface RoomContext {
     players: Player[];
     starredGoals: number[];
     showGoalDetails: boolean;
+    showCounters: boolean;
     connect: (
         nickname: string,
         password: string,
@@ -71,6 +72,7 @@ interface RoomContext {
     toggleGoalStar: (row: number, col: number) => void;
     revealCard: () => void;
     toggleGoalDetails: () => void;
+    toggleCounters: () => void;
 }
 
 export const RoomContext = createContext<RoomContext>({
@@ -82,6 +84,7 @@ export const RoomContext = createContext<RoomContext>({
     players: [],
     starredGoals: [],
     showGoalDetails: false,
+    showCounters: false,
     async connect() {
         return { success: false };
     },
@@ -99,6 +102,7 @@ export const RoomContext = createContext<RoomContext>({
     toggleGoalStar() {},
     revealCard() {},
     toggleGoalDetails() {},
+    toggleCounters() {},
 });
 
 interface RoomContextProps {
@@ -134,6 +138,11 @@ export function RoomContextProvider({ slug, children }: RoomContextProps) {
         getBoardSnapshot,
         getServerSnapshot,
     );
+
+    const [showCounters, setShowCounters] = useState(false);
+    const toggleCounters = useCallback(() => {
+        setShowCounters((curr) => !curr);
+    }, []);
 
     // incoming messages
     const onChatMessage = useCallback((message: ChatMessage) => {
@@ -526,6 +535,7 @@ export function RoomContextProvider({ slug, children }: RoomContextProps) {
                 players,
                 starredGoals,
                 showGoalDetails,
+                showCounters,
                 connect,
                 sendChatMessage,
                 markGoal,
@@ -541,6 +551,7 @@ export function RoomContextProvider({ slug, children }: RoomContextProps) {
                 toggleGoalStar,
                 revealCard,
                 toggleGoalDetails,
+                toggleCounters,
             }}
         >
             {children}


### PR DESCRIPTION
Adds a toggleable goal counter to board cells, allowing players to track their goal progress. This data is local only and does not get synchronized to the server.