### PR TITLE
Basic Automated Room Cleanup

### DIFF
--- a/api/src/Environment.ts
+++ b/api/src/Environment.ts
@@ -3,6 +3,10 @@ import 'dotenv/config';
 export const port = process.env.PORT || 8000;
 export const testing = !!process.env.TESTING;
 export const roomTokenSecret = process.env.ROOM_TOKEN_SECRET || '';
+export const roomCleanupInterval =
+    Number(process.env.ROOM_CLEANUP_INTERVAL) || 60000;
+export const roomCleanupInactive =
+    Number(process.env.ROOM_CLEANUP_INACTIVE) || 600000;
 export const sessionSecret = process.env.SESSION_SECRET || '';
 export const clientUrl = process.env.CLIENT_URL ?? '';
 export const smtpHost = process.env.SMTP_HOST ?? '';

--- a/api/src/Environment.ts
+++ b/api/src/Environment.ts
@@ -4,9 +4,9 @@ export const port = process.env.PORT || 8000;
 export const testing = !!process.env.TESTING;
 export const roomTokenSecret = process.env.ROOM_TOKEN_SECRET || '';
 export const roomCleanupInterval =
-    Number(process.env.ROOM_CLEANUP_INTERVAL) || 60000;
+    Number(process.env.ROOM_CLEANUP_INTERVAL) || 1000 * 60 * 60;
 export const roomCleanupInactive =
-    Number(process.env.ROOM_CLEANUP_INACTIVE) || 600000;
+    Number(process.env.ROOM_CLEANUP_INACTIVE) || 1000 * 60 * 60 * 3;
 export const sessionSecret = process.env.SESSION_SECRET || '';
 export const clientUrl = process.env.CLIENT_URL ?? '';
 export const smtpHost = process.env.SMTP_HOST ?? '';

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -189,7 +189,7 @@ export default class Room {
         this.lastMessage = Date.now();
         this.inactivityWarningTimeout = setTimeout(
             this.warnClose.bind(this),
-            1000 * 60 * 60 * 3,
+            roomCleanupInactive,
         );
     }
 

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -901,6 +901,7 @@ export default class Room {
         this.logInfo('Closing room.');
         this.sendSystemMessage('This room has been closed due to inactivity.');
         this.connections.forEach((connection) => {
+            this.handleSocketClose(connection);
             connection.close(1001, 'Room is closing.');
         });
         allRooms.delete(this.slug);

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -188,7 +188,7 @@ export default class Room {
 
         this.lastMessage = Date.now();
         this.inactivityWarningTimeout = setTimeout(
-            this.warnClose.bind(this),
+            () => this.warnClose(),
             roomCleanupInactive,
         );
     }
@@ -881,7 +881,7 @@ export default class Room {
     //#endregion
 
     //#region Utilities
-    private warnClose() {
+    warnClose() {
         this.logInfo('Sending inactivity warning.');
         this.sendSystemMessage(
             'This room close in 5 minutes if no activity is detected.',

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -426,6 +426,9 @@ export default class Room {
         this.identities.delete(auth.uuid);
         this.connections.delete(auth.uuid);
         addLeaveAction(this.id, identity.nickname, identity.color).then();
+        if (this.connections.size === 0) {
+            this.close();
+        }
         return { action: 'disconnected' };
     }
 
@@ -571,6 +574,10 @@ export default class Room {
                 'has left.',
             ]);
             addLeaveAction(this.id, identity.nickname, identity.color).then();
+
+            if (this.connections.size === 0) {
+                this.close();
+            }
             return true;
         }
         return false;

--- a/api/src/tests/core/Cleanup.test.ts
+++ b/api/src/tests/core/Cleanup.test.ts
@@ -1,0 +1,66 @@
+import { BingoMode } from '@prisma/client';
+import Room from '../../core/Room';
+import { roomCleanupInactive } from '../../Environment';
+import { mockReset } from 'jest-mock-extended';
+import { allRooms } from '../../core/RoomServer';
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+const createRoom = () =>
+    new Room(
+        'Unit Testing Room',
+        'Unit Test Game',
+        'unittest',
+        'unit-test-0001,',
+        '',
+        '1',
+        false,
+        BingoMode.LINES,
+        1,
+        false,
+    );
+
+describe('canClose()', () => {
+    it('Returns false for a newly initialized room', () => {
+        const room = createRoom();
+        expect(room.canClose()).toBe(false);
+    });
+
+    it('Returns false when the last message was before the timeout', () => {
+        const room = createRoom();
+        room.lastMessage = Date.now();
+        expect(room.canClose()).toBe(false);
+    });
+
+    it('Returns true when the last message was after the timeout', () => {
+        const room = createRoom();
+        room.lastMessage = Date.now() - roomCleanupInactive - 1000 * 60;
+        expect(room.canClose()).toBe(true);
+    });
+});
+
+describe('close()', () => {
+    it('Removes the room from the active room list', () => {
+        const room = createRoom();
+        allRooms.set(room.slug, room);
+        room.close();
+        expect(allRooms.has(room.slug)).toBe(false);
+    });
+});
+
+describe('Inactivity timeout', () => {
+    jest.useFakeTimers();
+    it('Gets called on a timeout', () => {
+        const room = createRoom();
+        jest.spyOn(room, 'warnClose');
+        jest.spyOn(room, 'close');
+        expect(room.warnClose).not.toHaveBeenCalled();
+        jest.runOnlyPendingTimers();
+        expect(room.warnClose).toHaveBeenCalledTimes(1);
+        expect(room.close).not.toHaveBeenCalled();
+        jest.runOnlyPendingTimers();
+        expect(room.close).toHaveBeenCalledTimes(1);
+    });
+});

--- a/api/src/tests/setup.ts
+++ b/api/src/tests/setup.ts
@@ -1,6 +1,7 @@
 import { mock } from 'jest-mock-extended';
 import { ApiToken } from '@prisma/client';
 import { prisma } from '../database/Database';
+import Room from '../core/Room';
 
 beforeEach(() => {
     // mockReset(prismaMock);


### PR DESCRIPTION
Adds a very basic room cleanup algorithm that closes rooms on regular intervals after periods of inactivity.

There are 3 methods for closing rooms
- A regularly occurring cleanup sweep that closes all open rooms that have not had a message sent in a specified period of time. Both the interval at which this cleanup runs and the minimum wait between messages before the room will be cleaned up is configurable. This generally will not catch many rooms, and is mostly meant to catch stragglers that don't get caught by the normal inactivity cleanup
- An inactivity timer that fires after 3 hours of inactivity on the room, providing a 5 minute warning before the room is closed.
- When the last websocket connection closes, or the last connected connection leaves the room, the room will close.

This can definitely be improved further, some potential points of improvement in the future
- Persist the "closed" status on the database, and force closed rooms to always be readonly
- Track when the objective of the room has been completed by every player, and shorten the timers