### PR TITLE
Room Layout Adjustments

### DIFF
--- a/web/src/app/(main)/rooms/[slug]/page.tsx
+++ b/web/src/app/(main)/rooms/[slug]/page.tsx
@@ -344,7 +344,7 @@ function RoomXl() {
                             columnGap: 1,
                         }}
                     >
-                        <Box>
+                        <Box sx={{ flexGrow: 1 }}>
                             <RoomInfo />
                         </Box>
                         <Box>

--- a/web/src/components/board/Cell.tsx
+++ b/web/src/components/board/Cell.tsx
@@ -100,6 +100,12 @@ export default function BoardCell({
                         zIndex: 10,
                         scale: '110%',
                     },
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: '100%',
+                    height: '100%',
                 }}
                 onClick={toggleSpace}
                 onContextMenu={(e) => {
@@ -112,7 +118,7 @@ export default function BoardCell({
             >
                 <Box
                     sx={{
-                        position: 'absolute',
+                        // position: 'absolute',
                         zIndex: 10,
                         display: 'flex',
                         height: '100%',
@@ -148,12 +154,10 @@ export default function BoardCell({
                 {showCounters && (
                     <Box
                         sx={{
-                            position: 'absolute',
                             bottom: 0,
                             display: 'flex',
                             backgroundColor: 'rgba(0,0,0,0.7)',
                             px: 0.5,
-                            py: 0.2,
                             width: '100%',
                             zIndex: 30,
                         }}
@@ -164,6 +168,7 @@ export default function BoardCell({
                                 updateProgress(-1);
                                 e.stopPropagation;
                             }}
+                            sx={{ padding: 0.25 }}
                         >
                             <Remove fontSize="small" />
                         </IconButton>
@@ -183,6 +188,7 @@ export default function BoardCell({
                                 updateProgress(+1);
                                 e.stopPropagation();
                             }}
+                            sx={{ padding: 0.25 }}
                         >
                             <Add fontSize="small" />
                         </IconButton>

--- a/web/src/components/board/Cell.tsx
+++ b/web/src/components/board/Cell.tsx
@@ -7,6 +7,7 @@ import { Cell } from '@playbingo/types';
 import { useCallback, useContext, useMemo, useState } from 'react';
 import { RoomContext } from '../../context/RoomContext';
 import TextFit from '../TextFit';
+import GoalCategories from '../game/GoalCategories';
 
 interface CellProps {
     cell: Cell;
@@ -57,8 +58,12 @@ export default function BoardCell({
                 showGoalDetails ? (
                     <>
                         <Box sx={{ pb: 1.5 }}>{goal.description}</Box>
-                        <Box>Difficulty: {goal.difficulty}</Box>
-                        <Box>Categories: {goal.categories?.join(', ')}</Box>
+                        {goal.difficulty && (
+                            <Box>Difficulty: {goal.difficulty}</Box>
+                        )}
+                        {goal.categories && (
+                            <Box>Categories: {goal.categories.join(', ')}</Box>
+                        )}
                     </>
                 ) : (
                     goal.description

--- a/web/src/components/room/PlayerInfo.tsx
+++ b/web/src/components/room/PlayerInfo.tsx
@@ -1,21 +1,41 @@
-import { Card, CardContent, Box, Typography, Button } from '@mui/material';
+import {
+    Card,
+    CardContent,
+    Box,
+    Typography,
+    Button,
+    FormControlLabel,
+    Switch,
+} from '@mui/material';
 import { ConnectionStatus, useRoomContext } from '../../context/RoomContext';
 import ColorSelect from './ColorSelect';
 
 export default function PlayerInfo() {
-    const { connectionStatus, nickname, disconnect } = useRoomContext();
+    const {
+        connectionStatus,
+        nickname,
+        disconnect,
+        showGoalDetails,
+        toggleGoalDetails,
+        showCounters,
+        toggleCounters,
+    } = useRoomContext();
     return (
         <Card>
             <CardContent>
                 <Box
                     sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        flexGrow: 1
-                    }}>
-                    <Typography variant="h6" sx={{
-                        flexGrow: 1
-                    }}>
+                        display: 'flex',
+                        alignItems: 'center',
+                        flexGrow: 1,
+                    }}
+                >
+                    <Typography
+                        variant="h6"
+                        sx={{
+                            flexGrow: 1,
+                        }}
+                    >
                         Playing as {nickname}
                     </Typography>
                     {connectionStatus !== ConnectionStatus.CLOSED && (
@@ -25,6 +45,27 @@ export default function PlayerInfo() {
                 <Box>
                     <Typography>Choose your color</Typography>
                     <ColorSelect />
+                </Box>
+                <Box sx={{ mt: 1.5 }}>
+                    <Typography variant="h6">Settings</Typography>
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={showCounters}
+                                onChange={toggleCounters}
+                            />
+                        }
+                        label="Show Counters"
+                    />
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={showGoalDetails}
+                                onChange={toggleGoalDetails}
+                            />
+                        }
+                        label="Show All Goal Details"
+                    />
                 </Box>
             </CardContent>
         </Card>

--- a/web/src/components/room/RoomControlDialog.tsx
+++ b/web/src/components/room/RoomControlDialog.tsx
@@ -33,15 +33,7 @@ export default function RoomControlDialog({
     show,
     close,
 }: RoomControlDialogProps) {
-    const {
-        roomData,
-        regenerateCard,
-        board,
-        showGoalDetails,
-        toggleGoalDetails,
-        showCounters,
-        toggleCounters,
-    } = useContext(RoomContext);
+    const { roomData, regenerateCard, board } = useContext(RoomContext);
 
     const modes = useAsync(async () => {
         if (!roomData) {
@@ -156,25 +148,6 @@ export default function RoomControlDialog({
                         pt: 2,
                     }}
                 >
-                    <Typography variant="h6">Settings</Typography>
-                    <FormControlLabel
-                        control={
-                            <Switch
-                                checked={showCounters}
-                                onChange={toggleCounters}
-                            />
-                        }
-                        label="Show Counters"
-                    />
-                    <FormControlLabel
-                        control={
-                            <Switch
-                                checked={showGoalDetails}
-                                onChange={toggleGoalDetails}
-                            />
-                        }
-                        label="Show All Goal Details"
-                    />
                     <Typography variant="h6">Local Actions</Typography>
                     <Typography variant="caption">
                         These actions are potentially destructive and should


### PR DESCRIPTION
Makes several small but meaningful adjustments to the layout of rooms
- Moves room controls from the settings dialog to the player control card, exposing the functionality more freely
- Fixed a bug that caused the room info card to shrink at high resolutions
- Fixed a bug that caused counters to render on top of text for long goals
- Fixed a bug that caused the labels for difficulty or categories to appear in the hover bubble even if the goal has no values defined for that field