### PR TITLE
feat: Difficulty distribution board layout

### DIFF
--- a/api/src/core/generation/BoardGenerator.ts
+++ b/api/src/core/generation/BoardGenerator.ts
@@ -43,6 +43,8 @@ export class BoardGenerator {
 
     customBoardLayout?: LayoutCell[][];
 
+    difficultyDistribution?: { difficulty: number; count: number }[];
+
     goalsByDifficulty: { [d: number]: GeneratorGoal[] } = {};
     goalsByCategoryId: { [id: string]: GeneratorGoal[] } = {};
     goalCopies: { [k: string]: number } = {};
@@ -90,6 +92,11 @@ export class BoardGenerator {
         this.customBoardLayout =
             config.boardLayout.mode === 'custom'
                 ? config.boardLayout.layout
+                : undefined;
+
+        this.difficultyDistribution =
+            (config.boardLayout as any).mode === 'difficulty-distribution'
+                ? (config.boardLayout as any).distribution
                 : undefined;
     }
 

--- a/api/src/core/generation/BoardGenerator.ts
+++ b/api/src/core/generation/BoardGenerator.ts
@@ -95,8 +95,8 @@ export class BoardGenerator {
                 : undefined;
 
         this.difficultyDistribution =
-            (config.boardLayout as any).mode === 'difficulty-distribution'
-                ? (config.boardLayout as any).distribution
+            config.boardLayout.mode === 'difficulty-distribution'
+                ? config.boardLayout.distribution
                 : undefined;
     }
 

--- a/api/src/core/generation/BoardLayoutGenerator.ts
+++ b/api/src/core/generation/BoardLayoutGenerator.ts
@@ -1,15 +1,13 @@
 import { GeneratorSettings } from '@playbingo/shared';
-import { BoardGenerator, LayoutCell } from './BoardGenerator';
 import { chunk, shuffle } from '../../util/Array';
+import { BoardGenerator, LayoutCell } from './BoardGenerator';
 
 type BoardLayout = GeneratorSettings['boardLayout'];
 
 export type BoardLayoutGenerator = (generator: BoardGenerator) => void;
 
 export const createLayoutGenerator = (strategy: BoardLayout) => {
-    const mode = (strategy as any).mode;
-
-    switch (mode) {
+    switch (strategy.mode) {
         case 'random':
             return noLayout;
         case 'srlv5':
@@ -21,7 +19,8 @@ export const createLayoutGenerator = (strategy: BoardLayout) => {
         case 'difficulty-distribution':
             return difficultyDistribution;
         default:
-            throw Error(`Unknown GenerationListMode strategy: ${mode}`);
+            // should never happen, strategy.mode is typed as never if the switch is properly exhaustive
+            throw Error('Unknown GenerationListMode strategy');
     }
 };
 

--- a/api/src/core/generation/BoardLayoutGenerator.ts
+++ b/api/src/core/generation/BoardLayoutGenerator.ts
@@ -1,12 +1,15 @@
 import { GeneratorSettings } from '@playbingo/shared';
 import { BoardGenerator, LayoutCell } from './BoardGenerator';
+import { chunk, shuffle } from '../../util/Array';
 
 type BoardLayout = GeneratorSettings['boardLayout'];
 
 export type BoardLayoutGenerator = (generator: BoardGenerator) => void;
 
 export const createLayoutGenerator = (strategy: BoardLayout) => {
-    switch (strategy.mode) {
+    const mode = (strategy as any).mode;
+
+    switch (mode) {
         case 'random':
             return noLayout;
         case 'srlv5':
@@ -15,8 +18,10 @@ export const createLayoutGenerator = (strategy: BoardLayout) => {
             return staticDifficulty;
         case 'custom':
             return custom;
+        case 'difficulty-distribution':
+            return difficultyDistribution;
         default:
-            throw Error('Unknown GenerationListMode strategy');
+            throw Error(`Unknown GenerationListMode strategy: ${mode}`);
     }
 };
 
@@ -102,4 +107,27 @@ const custom: BoardLayoutGenerator = (generator) => {
         throw new Error('Custom board layout not provided');
     }
     generator.layout = generator.customBoardLayout;
+};
+
+const difficultyDistribution: BoardLayoutGenerator = (generator) => {
+    if (!generator.difficultyDistribution) {
+        throw new Error('Difficulty distribution configuration not provided');
+    }
+
+    const difficulties: number[] = [];
+    generator.difficultyDistribution.forEach((difficulty) => {
+        difficulties.push(
+            ...Array(difficulty.count).fill(difficulty.difficulty),
+        );
+    });
+
+    shuffle(difficulties, generator.seed);
+
+    generator.layout = chunk(
+        difficulties.map((diff) => ({
+            selectionCriteria: 'difficulty',
+            difficulty: diff,
+        })),
+        5,
+    );
 };

--- a/api/src/tests/core/boardGenerator.test.ts
+++ b/api/src/tests/core/boardGenerator.test.ts
@@ -281,13 +281,13 @@ describe('Board Layout', () => {
         it('Generates the correct layout', () => {
             generator.reset();
             generator.generateBoardLayout();
-            expect(generator.layout).toEqual(correctLayout);
+            expect(generator.layout).toStrictEqual(correctLayout);
         });
 
         it('Is unaffected by seed', () => {
             generator.reset(12345);
             generator.generateBoardLayout();
-            expect(generator.layout).toEqual(correctLayout);
+            expect(generator.layout).toStrictEqual(correctLayout);
         });
     });
 
@@ -355,7 +355,7 @@ describe('Board Layout', () => {
             generator.generateBoardLayout();
             const layout2 = generator.layout;
 
-            expect(layout1).not.toEqual(layout2);
+            expect(layout1).not.toStrictEqual(layout2);
         });
 
         it('Generates the same layout with the same seed', () => {
@@ -367,7 +367,7 @@ describe('Board Layout', () => {
             generator.generateBoardLayout();
             const layout2 = generator.layout;
 
-            expect(layout1).toEqual(layout2);
+            expect(layout1).toStrictEqual(layout2);
         });
 
         it('Handles single difficulty distribution', () => {
@@ -501,17 +501,17 @@ describe('Goal Restriction', () => {
             // the sample goals only have one category each so we can just
             // expect categories[0] to not equal
             restrictedGoals.forEach((r) => {
-                expect(r.categories[0]).not.toEqual(g.categories[0]);
+                expect(r.categories[0]).not.toStrictEqual(g.categories[0]);
             });
 
             restrictedGoals = generator.validGoalsForCell(1, 0);
             restrictedGoals.forEach((r) => {
-                expect(r.categories[0]).not.toEqual(g.categories[0]);
+                expect(r.categories[0]).not.toStrictEqual(g.categories[0]);
             });
 
             restrictedGoals = generator.validGoalsForCell(2, 2);
             restrictedGoals.forEach((r) => {
-                expect(r.categories[0]).not.toEqual(g.categories[0]);
+                expect(r.categories[0]).not.toStrictEqual(g.categories[0]);
             });
         });
     });
@@ -673,7 +673,7 @@ describe('Full Generation', () => {
         generator.reset(12345);
         generator.generateBoard();
         const board2 = generator.board;
-        expect(board1).toEqual(board2);
+        expect(board1).toStrictEqual(board2);
     });
 
     it('Generates the same board given the same seed (SRLv5)', () => {
@@ -690,7 +690,7 @@ describe('Full Generation', () => {
         generator.reset(12345);
         generator.generateBoard();
         const board2 = generator.board;
-        expect(board1).toEqual(board2);
+        expect(board1).toStrictEqual(board2);
     });
 
     it('Generates a board with maximum restrictions', () => {

--- a/api/src/tests/core/boardGenerator.test.ts
+++ b/api/src/tests/core/boardGenerator.test.ts
@@ -91,8 +91,8 @@ describe('Goal Filters', () => {
             generator.goals.forEach((g) => {
                 const validCatNames = ['Category 1', 'Category 4'];
                 const hasCat = g.categories.some((cat) =>
-                    validCatNames.includes(cat.name)
-                )
+                    validCatNames.includes(cat.name),
+                );
                 expect(hasCat).toBeTruthy();
             });
         });
@@ -290,6 +290,116 @@ describe('Board Layout', () => {
             expect(generator.layout).toEqual(correctLayout);
         });
     });
+
+    describe('Difficulty Distribution', () => {
+        const generator = new BoardGenerator(goals, categories, {
+            goalFilters: [],
+            goalTransformation: [],
+            boardLayout: {
+                mode: 'difficulty-distribution',
+                distribution: [
+                    { difficulty: 1, count: 10 },
+                    { difficulty: 2, count: 8 },
+                    { difficulty: 3, count: 5 },
+                    { difficulty: 4, count: 2 },
+                ],
+            },
+            restrictions: [],
+            adjustments: [],
+        });
+
+        it('Generates the correct number of cells for each difficulty', () => {
+            generator.reset();
+            generator.generateBoardLayout();
+            const layout = generator.layout;
+
+            const difficultyCounts: { [key: number]: number } = {};
+
+            layout.forEach((row) => {
+                row.forEach((cell) => {
+                    if (cell.selectionCriteria === 'difficulty') {
+                        const difficulty = cell.difficulty;
+                        difficultyCounts[difficulty] =
+                            (difficultyCounts[difficulty] || 0) + 1;
+                    }
+                });
+            });
+
+            expect(difficultyCounts[1]).toBe(10);
+            expect(difficultyCounts[2]).toBe(8);
+            expect(difficultyCounts[3]).toBe(5);
+            expect(difficultyCounts[4]).toBe(2);
+        });
+
+        it('Generates different layouts with different seeds', () => {
+            const generator = new BoardGenerator(goals, categories, {
+                goalFilters: [],
+                goalTransformation: [],
+                boardLayout: {
+                    mode: 'difficulty-distribution',
+                    distribution: [
+                        { difficulty: 1, count: 10 },
+                        { difficulty: 2, count: 8 },
+                        { difficulty: 3, count: 5 },
+                        { difficulty: 4, count: 2 },
+                    ],
+                },
+                restrictions: [],
+                adjustments: [],
+            });
+            generator.reset(12345);
+            generator.generateBoardLayout();
+            const layout1 = generator.layout;
+
+            generator.reset(54321);
+            generator.generateBoardLayout();
+            const layout2 = generator.layout;
+
+            expect(layout1).not.toEqual(layout2);
+        });
+
+        it('Generates the same layout with the same seed', () => {
+            generator.reset(12345);
+            generator.generateBoardLayout();
+            const layout1 = generator.layout;
+
+            generator.reset(12345);
+            generator.generateBoardLayout();
+            const layout2 = generator.layout;
+
+            expect(layout1).toEqual(layout2);
+        });
+
+        it('Handles single difficulty distribution', () => {
+            const singleDifficultyGenerator = new BoardGenerator(
+                goals,
+                categories,
+                {
+                    goalFilters: [],
+                    goalTransformation: [],
+                    boardLayout: {
+                        mode: 'difficulty-distribution' as any,
+                        distribution: [{ difficulty: 2, count: 25 }],
+                    },
+                    restrictions: [],
+                    adjustments: [],
+                },
+            );
+
+            singleDifficultyGenerator.reset();
+            singleDifficultyGenerator.generateBoardLayout();
+            const layout = singleDifficultyGenerator.layout;
+
+            layout.forEach((row) => {
+                row.forEach((cell) => {
+                    expect(cell.selectionCriteria).toBe('difficulty');
+                    if (cell.selectionCriteria === 'difficulty') {
+                        expect(cell.difficulty).toBe(2);
+                    }
+                });
+            });
+        });
+    });
 });
 
 describe('Goal Selection', () => {
@@ -306,7 +416,7 @@ describe('Goal Selection', () => {
         generator.layout = [[{ selectionCriteria: 'category', category: '0' }]];
         const goals = generator.validGoalsForCell(0, 0);
         goals.forEach((goal) => {
-            const catNames = goal.categories.map(c => c.name)
+            const catNames = goal.categories.map((c) => c.name);
             expect(catNames).toContain('Category 1');
         });
     });
@@ -348,7 +458,7 @@ describe('Goal Selection', () => {
         ];
         let goals = generator.validGoalsForCell(0, 0);
         goals.forEach((goal) => {
-            const catNames = goal.categories.map(c => c.name)
+            const catNames = goal.categories.map((c) => c.name);
             expect(catNames).toContain('Category 3');
         });
         goals = generator.validGoalsForCell(0, 1);
@@ -361,7 +471,7 @@ describe('Goal Selection', () => {
         });
         goals = generator.validGoalsForCell(1, 1);
         goals.forEach((goal) => {
-            const catNames = goal.categories.map(c => c.name)
+            const catNames = goal.categories.map((c) => c.name);
             expect(catNames).toContain('Category 6');
         });
     });

--- a/shared/GeneratorSettings.ts
+++ b/shared/GeneratorSettings.ts
@@ -156,6 +156,43 @@ export const makeGeneratorSchema = (categories: GoalCategory[]) => {
                 .meta({ title: 'Layout' })
                 .default([[{ selectionCriteria: 'random' }]]),
         }),
+        z.object({
+            mode: z.literal('difficulty-distribution').meta({
+                title: 'Difficulty Distribution',
+                description:
+                    'Generates a board that distributes goals by difficulty across the board. Each difficulty is placed a specified number of times randomly across the board. Goals with an invalid difficulty will be ignored.',
+            }),
+            distribution: z
+                .array(
+                    z.object({
+                        difficulty: z
+                            .number()
+                            .int()
+                            .min(1, 'Difficulty must be at least 1')
+                            .meta({ title: 'Difficulty' }),
+                        count: z
+                            .number()
+                            .int()
+                            .min(1, 'Count must be at least 1')
+                            .meta({ title: 'Number of Slots' }),
+                    }),
+                )
+                .min(
+                    1,
+                    'At least one difficulty distribution must be specified',
+                )
+                .refine(
+                    (arr) => {
+                        const totalSlots = arr.reduce(
+                            (sum, item) => sum + item.count,
+                            0,
+                        );
+                        return totalSlots === 25; // Standard 5x5 board
+                    },
+                    { error: 'Total slots must equal 25 for a 5x5 board' },
+                )
+                .meta({ title: 'Difficulty Distribution' }),
+        }),
     ]);
 
     const GenerationGoalRestrictionSchema = z.discriminatedUnion('type', [


### PR DESCRIPTION
Adds an option for a difficulty distribution based board layout. Takes pairs of values as the configuration, representing the difficulty and the number of goals of that difficulty to place on the board. The layout is constructed randomly. This is part of recreating the current functionality of difficulty variants in the new variant framework