### PR TITLE
fix: Correctly use seed in the new generator

### DIFF
--- a/api/prisma/migrations/20260323043004_add_seed_to_room_data/migration.sql
+++ b/api/prisma/migrations/20260323043004_add_seed_to_room_data/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Room" ADD COLUMN     "seed" INTEGER;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -145,6 +145,7 @@ model Room {
   name             String
   private          Boolean
   password         String?
+  seed             Int?
   history          RoomAction[]
   game             Game?        @relation(fields: [gameId], references: [id])
   gameId           String?

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -107,6 +107,7 @@ export default class Room {
     variantName: string;
     exploration: boolean = false;
     alwaysRevealedMask: bigint = 0n;
+    seed: number;
 
     lastGenerationMode: BoardGenerationOptions;
 
@@ -138,6 +139,7 @@ export default class Room {
         lineCount: number,
         racetimeEligible: boolean,
         variantName: string,
+        seed: number,
         explorationStart?: string,
         racetimeUrl?: string,
         generatorSettings?: GeneratorSettings,
@@ -179,6 +181,8 @@ export default class Room {
         );
 
         this.players = new Map<string, Player>();
+
+        this.seed = seed;
 
         if (explorationStart) {
             this.exploration = true;
@@ -246,6 +250,7 @@ export default class Room {
             );
             generator.reset(options.seed);
             generator.generateBoard();
+            this.seed = generator.seed;
             this.board = generator.board.map((row) =>
                 row.map((goal) => ({
                     goal: goal,
@@ -427,6 +432,7 @@ export default class Room {
                 name: this.name,
                 gameSlug: this.gameSlug,
                 newGenerator: this.newGenerator,
+                seed: this.seed,
                 racetimeConnection: {
                     gameActive: this.racetimeEligible,
                     url: this.raceHandler.url,
@@ -621,6 +627,7 @@ export default class Room {
                 slug: this.slug,
                 name: this.name,
                 gameSlug: this.gameSlug,
+                seed: this.seed,
                 racetimeConnection: {
                     url,
                 },
@@ -643,6 +650,7 @@ export default class Room {
                 slug: this.slug,
                 name: this.name,
                 gameSlug: this.gameSlug,
+                seed: this.seed,
                 racetimeConnection: {
                     url: undefined,
                 },

--- a/api/src/core/Room.ts
+++ b/api/src/core/Room.ts
@@ -244,6 +244,7 @@ export default class Room {
                 categories,
                 this.generatorSettings,
             );
+            generator.reset(options.seed);
             generator.generateBoard();
             this.board = generator.board.map((row) =>
                 row.map((goal) => ({

--- a/api/src/database/Rooms.ts
+++ b/api/src/database/Rooms.ts
@@ -14,6 +14,7 @@ export const createRoom = (
     lineCount: number = 1,
     variant?: string,
     explorationStart?: string,
+    seed?: number,
 ) => {
     return prisma.room.create({
         data: {
@@ -28,6 +29,7 @@ export const createRoom = (
             variant: variant ? { connect: { id: variant } } : undefined,
             exploration: !!explorationStart,
             explorationStart,
+            seed,
         },
     });
 };

--- a/api/src/routes/rooms/Rooms.ts
+++ b/api/src/routes/rooms/Rooms.ts
@@ -64,12 +64,12 @@ rooms.post('/', async (req, res) => {
         lineCount,
         generationMode,
         hideCard,
-        seed,
         spectator,
         exploration,
         explorationStart,
         explorationStartCount,
     } = req.body;
+    const seed = req.body.seed ?? Math.ceil(999999 * Math.random());
 
     if (!name || !game || !nickname /*|| !variant || !mode*/) {
         res.status(400).send('Missing required element(s).');
@@ -176,6 +176,7 @@ rooms.post('/', async (req, res) => {
                 ? `${explorationStartCount}`
                 : explorationStart
             : undefined,
+        seed,
     );
     const room = new Room(
         name,
@@ -191,6 +192,7 @@ rooms.post('/', async (req, res) => {
             !!gameData.racetimeCategory &&
             !!gameData.racetimeGoal,
         variantName,
+        seed,
         exploration
             ? explorationStart === 'RANDOM'
                 ? explorationStartCount
@@ -304,6 +306,7 @@ async function getOrLoadRoom(slug: string): Promise<Room | null> {
             !!dbRoom.game.racetimeGoal) ||
             !!dbRoom.racetimeRoom,
         variantName,
+        dbRoom.seed ?? 0,
         dbRoom.explorationStart ?? undefined,
         dbRoom.racetimeRoom ?? '',
         generatorSettings,
@@ -426,6 +429,7 @@ rooms.get('/:slug', async (req, res) => {
         name: room.name,
         gameSlug: room.gameSlug,
         newGenerator: room.newGenerator,
+        seed: room.seed,
         racetimeConnection: {
             gameActive: room.racetimeEligible,
             url: room.raceHandler.url,

--- a/api/src/tests/core/Cleanup.test.ts
+++ b/api/src/tests/core/Cleanup.test.ts
@@ -21,6 +21,7 @@ const createRoom = () =>
         1,
         false,
         'Normal',
+        1,
     );
 
 describe('canClose()', () => {

--- a/schema/schemas/RoomData.json
+++ b/schema/schemas/RoomData.json
@@ -9,7 +9,8 @@
         "gameSlug",
         "newGenerator",
         "variant",
-        "mode"
+        "mode",
+        "seed"
     ],
     "description": "Basic information about a room",
     "properties": {
@@ -40,6 +41,9 @@
         },
         "mode": {
             "type": "string"
+        },
+        "seed": {
+            "type": "number"
         }
     },
     "$defs": {

--- a/schema/types/RoomData.d.ts
+++ b/schema/types/RoomData.d.ts
@@ -21,6 +21,7 @@ export interface RoomData {
   token?: string;
   variant: string;
   mode: string;
+  seed: number;
 }
 export interface RacetimeConnection {
   /**

--- a/schema/types/ServerMessage.d.ts
+++ b/schema/types/ServerMessage.d.ts
@@ -129,6 +129,7 @@ export interface RoomData {
   token?: string;
   variant: string;
   mode: string;
+  seed: number;
 }
 export interface RacetimeConnection {
   /**

--- a/web/src/components/room/RoomInfo.tsx
+++ b/web/src/components/room/RoomInfo.tsx
@@ -55,6 +55,8 @@ export default function RoomInfo() {
                             <Typography>{roomData.variant}</Typography>
                             <Box sx={{ borderLeft: 1 }} />
                             <Typography>{roomData.mode}</Typography>
+                            <Box sx={{ borderLeft: 1 }} />
+                            <Typography>Seed: {roomData.seed}</Typography>
                         </Box>
                         <ConnectionState />
                     </CardContent>


### PR DESCRIPTION
Fixes user provided seeds not being passed to the new generator correctly, resulting in a random seed being used every time. Additionally adds the seed to the room information so that it can be displayed to users. It is also now persisted in the database